### PR TITLE
Fixes to pigro and puffin internet 

### DIFF
--- a/apps/PiGro/install
+++ b/apps/PiGro/install
@@ -26,5 +26,9 @@ chmod +x scripts/rmlxde.sh
 chmod +x scripts/terminal.sh
 chmod +x scripts/xfce4fix.sh
 chmod +x scripts/uninstall.sh
+chmod +x scripts/fmsudo.sh
+chmod +x scripts/pi-apps.sh
+chmod +x scripts/ov_2.sh
+chmod +x scripts/ov_1.sh
 cp pigro.desktop  ~/Desktop
 cp pigro.desktop ~/.local/share/applications/

--- a/apps/PiGro/uninstall
+++ b/apps/PiGro/uninstall
@@ -8,7 +8,7 @@ function error {
 }
 
 #if your app installs any packages, keep this command here so those packages will be removed.
-"${DIRECTORY}/purge-installed"neofetch"$(dirname "$0")" || exit 1
+"${DIRECTORY}/purge-installed" "neofetch" "$(dirname "$0")" || exit 1
 
 rm -rf ~/PiGro-Aid-
 

--- a/apps/PiGro/uninstall
+++ b/apps/PiGro/uninstall
@@ -8,8 +8,9 @@ function error {
 }
 
 #if your app installs any packages, keep this command here so those packages will be removed.
-"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
+"${DIRECTORY}/purge-installed"neofetch"$(dirname "$0")" || exit 1
 
 rm -rf ~/PiGro-Aid-
 
-rm ~/Desktop/pigro.desktop /usr/share/applications/pigro.desktop
+rm ~/Desktop/pigro.desktop ~/.local/share/applications/pigro.desktop
+

--- a/apps/PiGro/uninstall
+++ b/apps/PiGro/uninstall
@@ -8,7 +8,7 @@ function error {
 }
 
 #if your app installs any packages, keep this command here so those packages will be removed.
-"${DIRECTORY}/purge-installed" "neofetch" "$(dirname "$0")" || exit 1
+"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
 
 rm -rf ~/PiGro-Aid-
 

--- a/apps/Puffin Browser Demo/uninstall
+++ b/apps/Puffin Browser Demo/uninstall
@@ -7,4 +7,4 @@ function error {
   exit 1
 }
 
-sudo apt purge -y puffin-internet-terminal puffin-internet-terminal-demo
+sudo apt purge -y puffin-internet-terminal-demo puffin-internet-terminal 

--- a/apps/Puffin Browser Demo/uninstall
+++ b/apps/Puffin Browser Demo/uninstall
@@ -7,4 +7,5 @@ function error {
   exit 1
 }
 
-sudo apt purge -y puffin-internet-terminal-demo puffin-internet-terminal 
+sudo apt purge -y puffin-internet-terminal-demo
+sudo apt purge -y puffin-internet-terminal 


### PR DESCRIPTION
## puffin internet:
### problem:
puffin wasn't uninstalling, issue: the package name was `puffin-internet-terminal-demo` and not `puffin-internet-terminal` and even though that seems to be taken into account in the uninstall script, it didn't work. 
### fix: 
splitting the `apt purge` command to 2 commands one after the other.

## pigro:
### problem:
pigro installer not making all scripts executable.
### fix:
adding the needed lines to install script.
### problem:
the uninstaller script trying to remove menu shortcut from `/usr/share/applications` instead of `~/.local/share/applications`.
### fix:
change line in uninstall script.