### PR TITLE
update etcher, improve puffin internet

### DIFF
--- a/apps/BalenaEtcher/install-32
+++ b/apps/BalenaEtcher/install-32
@@ -9,8 +9,8 @@ function error {
 
 rm -f ./etcher_1.5.109_armhf.deb
 
-wget https://github.com/Itai-Nelken/Etcher-arm-32-64/raw/main/balena-etcher-electron_1.5.110%2B1f8f7ad7_armv7l.deb -O ~/etcher.deb || error "Failed to download!"
+wget https://github.com/Itai-Nelken/Etcher-arm-32-64/releases/download/v1.5.111/balena-etcher-electron_1.5.111+e708212d_armv7l.deb -O ~/etcher-v1.5.111_armv7l.deb || error "Failed to download!"
 
-sudo apt install -y --fix-broken ~/etcher.deb  || error "failed to install deb file!"
-rm -f ~/etcher.deb
+sudo apt install -y --fix-broken ~/etcher-v1.5.111_armv7l.deb  || error "failed to install deb file!"
+rm -f ~/etcher-v1.5.111_armv7l.deb
 exit 0

--- a/apps/BalenaEtcher/install-64
+++ b/apps/BalenaEtcher/install-64
@@ -11,8 +11,8 @@ function error {
 
 rm -f ./balena-etcher-electron_1.5.110%2B1f8f7ad7_arm64.deb
 
-wget https://github.com/Itai-Nelken/Etcher-arm-32-64/raw/main/balena-etcher-electron_1.5.110%2B1f8f7ad7_arm64.deb -O ~/etcher.deb || error "Failed to download!"
+wget https://github.com/Itai-Nelken/Etcher-arm-32-64/releases/download/v1.5.111/balena-etcher-electron_1.5.111+e708212d_arm64.deb -O ~/etcher-v1.5.111_arm64.deb || error "Failed to download!"
 
-sudo apt install -y --fix-broken ~/etcher.deb || error "failed to install deb file!"
-rm -f ~/etcher.deb
+sudo apt install -y --fix-broken ~/etcher-v1.5.111_arm64.deb || error "failed to install deb file!"
+rm -f ~/etcher-v1.5.111_arm64.deb
 exit 0

--- a/apps/Puffin Browser Demo/install-32
+++ b/apps/Puffin Browser Demo/install-32
@@ -11,4 +11,5 @@ wget https://download.puffinbrowser.com/linux/raspbian/puffin-internet-terminal-
 
 sudo apt install -y --fix-missing ~/puffin-internet-terminal.deb || error "APT failed to install puffin-internet-terminal.deb!"
 
+rm ~/puffin-internet-terminal.deb
 


### PR DESCRIPTION
update etcher to [v1.5.111](https://github.com/Itai-Nelken/Etcher-arm-32-64/releases/tag/v1.5.111).
make puffin internet install script remove `puffin-internet-terminal.deb` after installing.