### PR TITLE
Add Minecraft Bedrock 64 bit install script

### DIFF
--- a/apps/Minecraft Bedrock/install-64
+++ b/apps/Minecraft Bedrock/install-64
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+DIRECTORY="$(dirname "$(dirname "$(dirname "$0")")")"
+function error {
+  echo -e "\\e[31m$1\\e[39m"
+  exit 1
+}
+
+# Get dependencies
+sudo dpkg --add-architecture armhf
+"${DIRECTORY}/pkg-install" "curl libx11-6:armhf libxext6:armhf libegl1-mesa:armhf zlib1g:armhf libstdc++6:armhf libgl1-mesa-dri:armhf libasound2:armhf libpulse0:armhf libcom-err2:armhf libgmp10:armhf libp11-kit0:armhf" "$(dirname "$0")" || exit 1
+
+#Download file
+cd ~
+curl -L https://github.com/ChristopherHX/linux-packaging-scripts/releases/download/ng.appimage/Minecraft_Bedrock_Launcher-arm_aarch64.0.0.619.AppImage --output MCBedrock.AppImage
+chmod +x MCBedrock.AppImage
+sudo mv MCBedrock.AppImage /usr/bin/MCBedrock.AppImage
+
+#Make Desktop file
+echo '[Desktop Entry]
+Version=1.1
+Type=Application
+Name=Minecraft Bedrock Launcher
+Comment=A Minecraft: Bedrock Edition
+Icon=$(dirname "$0")/icon-64.png
+Exec=bash -c "GALLIUM_HUD=simple,fps /usr/bin/MCBedrock.AppImage"
+Categories=Game;
+Terminal=false
+StartupNotify=true' > ~/.local/share/applications/minecraftbedrock.desktop
+


### PR DESCRIPTION
I haven't tested this yet (I haven't got piOS installed on a 64bit pi) but it should work fine - I based it a lot off the 32bit one:
- Added the architecture
- Changed the dependencies to the ones mentioned [here](https://github.com/ChristopherHX/linux-packaging-scripts/releases)
- Changed the download url

I was concerned about my use of `sudo` for adding the armhf architecture, but it seems that there is no "best practice"  implemented here yet and the 32 bit script already uses it to move the app image to `/usr/bin`