### PR TITLE
box86 improvement/bug fix

### DIFF
--- a/apps/Box86/install-32
+++ b/apps/Box86/install-32
@@ -17,7 +17,7 @@ fi
 git clone https://github.com/ptitSeb/box86 || error "failed to download repo!"
 cd box86 || error "failed to enter directory!"
 mkdir build; cd build
-cmake .. -DRPI4=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo || error "cmake failed!"
-make -j24 || error "make failed!"
+cmake .. -DRPI4=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DARM_DYNAREC=1 || error "cmake failed!"
+make -j4 || error "make failed!"
 sudo make install || error "sudo make install failed!"
 sudo systemctl restart systemd-binfmt


### PR DESCRIPTION
every time I tried to install box86 (on a new RPiOS 32bit install), it got stuck.
the error was a typo: `make -j24` instead of `make -j4`.
