### PR TITLE
Creating Symlink Only If Its Raspberry Pi OS

### DIFF
--- a/apps/Snap Store/install
+++ b/apps/Snap Store/install
@@ -14,7 +14,11 @@ sudo systemctl enable --now snapd.socket || error "Unable to enable snapd.socket
 sudo ln -s /var/lib/snapd/snap /snap || error "unable to create symbolic link between /var/lib/snapd/snap and /snap"
 sudo snap install core || error "Unable to install core"
 sudo snap install snap-store || error "Unable to install snap store"
-sudo rm -rf /usr/share/applications/snap
-ln -s /var/lib/snapd/desktop/applications /usr/share/applications/snap || sudo ln -s /var/lib/snapd/desktop/applications /usr/share/applications/snap || error "Failed to create symlink for Snap app shortcuts!"
 
+#Creating Symlink Only If Its Raspberry Pi OS
+if ! command -v twistver &> /dev/null
+then
+    sudo rm -rf /usr/share/applications/snap
+    ln -s /var/lib/snapd/desktop/applications /usr/share/applications/snap || sudo ln -s /var/lib/snapd/desktop/applications /usr/share/applications/snap || error "Failed to create symlink for Snap app shortcuts!"
+fi
 


### PR DESCRIPTION
According to this issue https://github.com/Botspot/pi-apps/issues/272 There is no need to create a symlink if its twister os. So I modified to code to only create a symlink if its raspberry pi os. I am checking if the os is twister os by checking if the binary twistver is there as its builtin in twiseros