### PR TITLE
wine uninstall script removes all desktop shortcuts

### DIFF
--- a/apps/Wine (x86)/uninstall
+++ b/apps/Wine (x86)/uninstall
@@ -13,7 +13,9 @@ sudo rm /usr/local/bin/winecfg
 sudo rm /usr/local/bin/wineserver
 rm -rf ~/wine
 
-rm ~/.local/share/applications/winecfg.desktop || error 'Failed to remove winecfg menu shortcut'
+rm ~/.local/share/applications/wine-config.desktop || error 'Failed to remove winecfg menu shortcut!'
+rm ~/.local/share/applications/winetricks.desktop || error 'Failed to remove winetricks menu shortcut!'
+rm ~/.local/share/applications/wine-explorer.desktop || error 'Failed to remove wine desktop menu shortcut!'
 
 #if your app installs any packages, keep this command here so those packages will be removed.
 "${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1


### PR DESCRIPTION
before this it tried to remove `~/.local/share/applications/winecfg.desktop` that doesn't even exist.