### PR TITLE
Change MCPI uninstall to properly remove packages

### DIFF
--- a/apps/Minecraft Pi (Modded)/uninstall
+++ b/apps/Minecraft Pi (Modded)/uninstall
@@ -7,5 +7,5 @@ function error {
   exit 1
 }
 
-sudo apt-get remove -y minecraft-pi-reborn-native mcpil
-sudo apt-get autoremove -y
+sudo apt-get remove -y minecraft-pi-native &>/dev/null || true
+sudo apt-get remove -y mcpil &>/dev/null || true


### PR DESCRIPTION
- In case a user accidently removes mcpil or something and runs uninstall, this will fix it since it removes both seprately
- Most of the time the user uninstalls just to upgrade. If a user truely uninstalled it, they would see the sudo apt autoremove thing.