### PR TITLE
Snapdrop: Links invalid, also add install-64

### DIFF
--- a/apps/Snapdrop/install-32
+++ b/apps/Snapdrop/install-32
@@ -8,7 +8,7 @@ function error {
 
 rm -f snapdrop-linux-armv7l.tar.xz
 
-wget https://github.com/chunky-milk/snapdrop-rpi/raw/master/snapdrop-linux-armv7l.tar.xz || error "Failed to download archive!"
+wget https://github.com/chunky-milk/snapdrop-rpi/releases/download/1.0/snapdrop-linux-armv7l.tar.xz || error "Failed to download archive!"
 tar -xvf snapdrop-linux-armv7l.tar.xz || error "Failed to extract archive!"
 rm -f snapdrop-linux-armv7l.tar.xz
 

--- a/apps/Snapdrop/install-64
+++ b/apps/Snapdrop/install-64
@@ -6,7 +6,7 @@ function error {
   exit 1
 }
 
-rm -f snapdrop-linux-armv7l.tar.xz
+rm -f snapdrop-linux-arm64.zip
 
 wget https://github.com/chunky-milk/snapdrop-rpi/releases/download/1.0/snapdrop-linux-arm64.zip || error "Failed to download archive!"
 unzip snapdrop-linux-arm64.zip || error "Failed to extract archive!"

--- a/apps/Snapdrop/install-64
+++ b/apps/Snapdrop/install-64
@@ -1,0 +1,26 @@
+#!/bin/bash
+DIRECTORY="$(dirname "$(dirname "$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )")")"
+
+function error {
+  echo -e "\\e[91m$1\\e[39m"
+  exit 1
+}
+
+rm -f snapdrop-linux-armv7l.tar.xz
+
+wget https://github.com/chunky-milk/snapdrop-rpi/releases/download/1.0/snapdrop-linux-arm64.zip || error "Failed to download archive!"
+unzip snapdrop-linux-arm64.zip || error "Failed to extract archive!"
+rm -f snapdrop-linux-arm64.zip || error "Failed to remove archive!"
+mv Snapdrop-linux-arm64 snapdrop
+
+# Desktop entry
+echo "[Desktop Entry]
+Name=Snapdrop
+GenericName=Local File Sharing
+Comment=Snapdrop: local file sharing in your browser. Inspired by Apple's Airdrop.
+Exec=$HOME/snapdrop/Snapdrop
+Icon=$(dirname "$0")/icon-64.png
+Terminal=true
+StartupNotify=true
+Categories=Network;
+Type=Application" > ~/.local/share/applications/snapdrop.desktop || error "Failed to create desktop shortcut!"


### PR DESCRIPTION
@Botspot the install scripts contain broken links, I've fixed them, and also added install-64