### PR TITLE
Force reinstall for mesa fix on MC Java

### DIFF
--- a/apps/Minecraft Java/install-32
+++ b/apps/Minecraft Java/install-32
@@ -7,11 +7,6 @@ function error {
   exit 1
 }
 
-#use the error function often!
-#If a certain command is necessary for installation to continue, then add this to the end of it:
-# || error 'reason'
-#example below:
-
 #Download java and launcher
 mkdir ~/Minecraft && cd ~/Minecraft && wget https://github.com/mikehooper/Minecraft/raw/main/setupMC.sh && chmod +x setupMC.sh && ./setupMC.sh || error 'Failed to install the launcher!'
 

--- a/apps/Minecraft Java/install-64
+++ b/apps/Minecraft Java/install-64
@@ -7,11 +7,6 @@ function error {
   exit 1
 }
 
-#use the error function often!
-#If a certain command is necessary for installation to continue, then add this to the end of it:
-# || error 'reason'
-#example below:
-
 #Download java and launcher
 mkdir ~/Minecraft && cd ~/Minecraft && wget https://github.com/mikehooper/Minecraft/raw/main/setupMC.sh && chmod +x setupMC.sh && ./setupMC.sh || error 'Failed to install the launcher!'
 


### PR DESCRIPTION
Basically this forces a reinstall of MC java, which pulls the new desktop shortcut from https://raw.githubusercontent.com/mobilegmYT/pi-apps-resources/main/Minecraft/minecraft.desktop. It forces OpenGL 3.0, which a lot of people say gives Minecraft and other apps better performance. I use this override on my own install personally.