### PR TITLE
Change nodejs to use nvm and not directly install from apt

### DIFF
--- a/apps/Node.js/install
+++ b/apps/Node.js/install
@@ -19,8 +19,9 @@ You need to install curl first. If you are on a debian system, this command shou
   exit 1
 fi
 
-#Add NodeSource repo:
-curl -sL https://deb.nodesource.com/setup_15.x | sudo -E bash - || error "Failed to add Nodesource repo!"
+#Install nvm manager:
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash || error "Failed to install nvm!"
+source ~/.bashrc
 
 #Install NodeJS:
-sudo apt install nodejs -y || error "Failed to install Node.JS"
+nvm install --lts

--- a/apps/Node.js/uninstall
+++ b/apps/Node.js/uninstall
@@ -8,11 +8,7 @@ function error {
 }
 
 #Uninstall NodeJS
-sudo apt purge nodejs -y || error "Failed to purge Node.JS!"
-sudo apt autoremove -y #who cares if this fails?
+nvm uninstall default || error "Failed to purge Node.JS!"
 
-#remove /etc/apt/sources.list.d/nodesource.list
-sudo rm /etc/apt/sources.list.d/nodesource.list || error "Failed to remove nodesource repo!"
-
-#if your app installs any packages, keep this command here so those packages will be removed.
-"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
+#Remove nvm
+sudo rm -rf ~/.nvm


### PR DESCRIPTION
I've noticed a error with the apt repo nodejs, which is that a lot of apps have root issues while running. Switching to using the nvm manager fixes those issues since it does root magic while installing node.