### PR TITLE
fix 'nvm: command not found' for Node.js install script

### DIFF
--- a/apps/Node.js/install
+++ b/apps/Node.js/install
@@ -21,7 +21,10 @@ fi
 
 #Install nvm manager:
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash || error "Failed to install nvm!"
-source ~/.bashrc
+#source ~/.bashrc
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
 #Install NodeJS:
 nvm install --lts


### PR DESCRIPTION
the commands were copied from `nvm`'s output.
Tested and works on TwisterOS 2.0.