### PR TITLE
Changed the description to VSCode

### DIFF
--- a/apps/Visual Studio Code/credits
+++ b/apps/Visual Studio Code/credits
@@ -1,2 +1,3 @@
 Install script written by RaspberryPiNews on YT
+Small change to description by CleanMachine1
 Original program made by Microsoft

--- a/apps/Visual Studio Code/description
+++ b/apps/Visual Studio Code/description
@@ -1,7 +1,5 @@
 Visual Studio Code is a free source-code editor made by Microsoft.
 Features include support for debugging, syntax highlighting, intelligent code completion, snippets, code refactoring, and embedded Git
 It supports most popular coding languages including Python, JavaScript, and more.
-Note: Visual Studio Code can be installed in Raspberry Pi OS via the default repositories  by running the command "sudo apt install code -y".
-This should be done instead unless you're using a different OS other than Raspberry Pi OS (Full or Desktop) which doesn't have the repositories 
-found in Raspberry Pi OS (http://archive.raspberrypi.org/ and http://raspbian.raspberrypi.org/)
+Note: If you are using Raspberry Pi OS, you don't need to install this app. Just run "sudo apt install code" in the terminal. Pi-Apps will still continue to ship VSCode so that non-PiOS users can still have access to it.
 

--- a/apps/Visual Studio Code/description
+++ b/apps/Visual Studio Code/description
@@ -2,5 +2,5 @@ Visual Studio Code is a free source-code editor made by Microsoft.
 Features include support for debugging, syntax highlighting, intelligent code completion, snippets, code refactoring, and embedded Git
 It supports most popular coding languages including Python, JavaScript, and more.
 Note: Visual Studio Code can be installed in Raspberry Pi OS via the default mirrors by running the command "sudo apt install code -y".
-This should be done instead unless you are using a different OS other than Raspberry Pi OS (Full or Desktop)
+This should be done instead unless you are using a different OS other than Raspberry Pi OS (Full or Desktop).
 

--- a/apps/Visual Studio Code/description
+++ b/apps/Visual Studio Code/description
@@ -1,6 +1,7 @@
 Visual Studio Code is a free source-code editor made by Microsoft.
 Features include support for debugging, syntax highlighting, intelligent code completion, snippets, code refactoring, and embedded Git
 It supports most popular coding languages including Python, JavaScript, and more.
-Note: Visual Studio Code can be installed in Raspberry Pi OS via the default mirrors by running the command "sudo apt install code -y".
-This should be done instead unless you are using a different OS other than Raspberry Pi OS (Full or Desktop).
+Note: Visual Studio Code can be installed in Raspberry Pi OS via the default repositories  by running the command "sudo apt install code -y".
+This should be done instead unless you're using a different OS other than Raspberry Pi OS (Full or Desktop) which doesn't have the repositories 
+found in Raspberry Pi OS (http://archive.raspberrypi.org/ and http://raspbian.raspberrypi.org/)
 

--- a/apps/Visual Studio Code/description
+++ b/apps/Visual Studio Code/description
@@ -1,3 +1,6 @@
 Visual Studio Code is a free source-code editor made by Microsoft.
 Features include support for debugging, syntax highlighting, intelligent code completion, snippets, code refactoring, and embedded Git
 It supports most popular coding languages including Python, JavaScript, and more.
+Note: Visual Studio Code can be installed in Raspberry Pi OS via the default mirrors by running the command "sudo apt install code -y".
+This should be done instead unless you are using a different OS other than Raspberry Pi OS (Full or Desktop)
+


### PR DESCRIPTION
I created an issue a little while ago regarding removing VSCode, since its been discussed and I am satisfied, I have just edited the description to let the user know that if they are using RPi-OS, they don't need to install it from MS servers, and rather just download from the raspberry pi repos 

Small change but a piece of useful information for someone who hasn't kept up with raspberry pi news