### PR TITLE
fix node.js installation (32bit)

### DIFF
--- a/apps/Node.js/install-32
+++ b/apps/Node.js/install-32
@@ -21,7 +21,7 @@ fi
 
 #Install nvm manager:
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash || error "Failed to install nvm!"
-export NVM_DIR="$HOME/.config/nvm"
+export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 


### PR DESCRIPTION
`NVM_DIR` was `~/.config/nvm` but it was supposed to be `~/.nvm`.

from the `nvm` install script output:
```
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
```

tested and works.
<details>
    <summary>pi-apps installation output (node.js was alreay installed on my system, but the script still failed without this fix)</summary>

```bash
Installing Node.js with install-32 script
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 13527  100 13527    0     0  27948      0 --:--:-- --:--:-- --:--:-- 28006
=> nvm is already installed in /home/pi/.nvm, trying to update using git
=> => Compressing and cleaning up git repository

=> nvm source string already in /home/pi/.bashrc
=> bash_completion source string already in /home/pi/.bashrc
=> You currently have modules installed globally with `npm`. These will no
=> longer be linked to the active version of Node when you install a new node
=> with `nvm`; and they may (depending on how you construct your `$PATH`)
=> override the binaries of modules installed with `nvm`:

/home/pi/.nvm/versions/node/v14.16.0/lib
\u251c\u2500\u2500 nativefier@43.0.0
=> If you wish to uninstall them at a later point (or re-install them under your
=> `nvm` Nodes), you can remove them from the system Node as follows:

     $ nvm use system
     $ npm uninstall -g a_module

=> Close and reopen your terminal to start using nvm or run the following to use it now:

export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
Installing latest LTS version.
v14.16.0 is already installed.
Now using node v14.16.0 (npm v7.6.3)

Installed Node.js successfully.

Closing in 30 seconds.
```

</details>