### PR TITLE
Update StackEdit and Whatsapp to a version built with a newer nativefier

### DIFF
--- a/apps/StackEdit/install-32
+++ b/apps/StackEdit/install-32
@@ -9,7 +9,7 @@ function error {
 
 cd $HOME
 echo "Downloading..."
-wget https://github.com/Itai-Nelken/Nativefier-WebApps/releases/download/v1.0/StackEdit-linux-armv7l.tar.xz || error 'Failed to Download!'
+wget https://github.com/Itai-Nelken/Nativefier-WebApps/releases/download/v2.0/StackEdit-linux-armv7l.tar.xz || error 'Failed to Download!'
 echo "extracting..."
 tar -xf StackEdit-linux-armv7l.tar.xz || error "Failed to extract!"
 echo "Renaming folder..."

--- a/apps/StackEdit/install-64
+++ b/apps/StackEdit/install-64
@@ -9,7 +9,7 @@ function error {
 
 cd $HOME
 echo "Downloading..."
-wget https://github.com/Itai-Nelken/Nativefier-WebApps/releases/download/v1.0/StackEdit-linux-arm64.tar.xz || error 'Failed to Download!'
+wget https://github.com/Itai-Nelken/Nativefier-WebApps/releases/download/v2.0/StackEdit-linux-arm64.tar.xz || error 'Failed to Download!'
 echo "extracting..."
 tar -xf StackEdit-linux-arm64.tar.xz || error "Failed to extract!"
 echo "Renaming folder..."

--- a/apps/Whatsapp/install-32
+++ b/apps/Whatsapp/install-32
@@ -9,7 +9,7 @@ function error {
 
 cd $HOME
 rm -f WhatsAppWeb-linux-armv7l.tar.xz
-wget https://github.com/Itai-Nelken/Nativefier-WebApps/releases/download/v1.0/WhatsAppWeb-linux-armv7l.tar.xz || error 'Failed to download!'
+wget https://github.com/Itai-Nelken/Nativefier-WebApps/releases/download/v2.0/WhatsAppWeb-linux-armv7l.tar.xz || error 'Failed to download!'
 tar -xf WhatsAppWeb-linux-armv7l.tar.xz || error "Failed to extract!"
 rm WhatsAppWeb-linux-armv7l.tar.xz
 mv "WhatsAppWeb-linux-armv7l" WhatsAppWeb

--- a/apps/Whatsapp/install-64
+++ b/apps/Whatsapp/install-64
@@ -9,7 +9,7 @@ function error {
 
 cd $HOME
 rm -f WhatsAppWeb-linux-arm64.tar.xz
-wget https://github.com/Itai-Nelken/Nativefier-WebApps/releases/download/v1.0/WhatsAppWeb-linux-arm64.tar.xz || error 'Failed to download!'
+wget https://github.com/Itai-Nelken/Nativefier-WebApps/releases/download/v2.0/WhatsAppWeb-linux-arm64.tar.xz || error 'Failed to download!'
 tar -xf WhatsAppWeb-linux-arm64.tar.xz || error "Failed to extract!"
 rm WhatsAppWeb-linux-arm64.tar.xz
 mv "WhatsAppWeb-linux-arm64" WhatsAppWeb


### PR DESCRIPTION
to eliminate the warning that the app was built with a old version of nativefier.