### PR TITLE
Installing flameshot to /tmp/.deb instead

### DIFF
--- a/apps/Flameshot/install-32
+++ b/apps/Flameshot/install-32
@@ -7,8 +7,8 @@ function error {
   exit 1
 }
 
-rm -f flameshot_armhf.deb
-wget -O flameshot_armhf.deb https://github.com/chunky-milk/raspbian-addons/raw/master/debian/pool/main/f/flameshot/flameshot_0.9.0-1_armhf.deb || error 'Failed to download flameshot deb file'
-sudo apt install ./flameshot_armhf.deb -yf || error 'Failed to install flameshot'
-rm -f flameshot_armhf.deb
+rm -f /tmp/flameshot_armhf.deb
+wget -O /tmp/flameshot_armhf.deb https://github.com/chunky-milk/raspbian-addons/raw/master/debian/pool/main/f/flameshot/flameshot_0.9.0-1_armhf.deb || error 'Failed to download flameshot deb file'
+sudo apt install /tmp/flameshot_armhf.deb -yf || error 'Failed to install flameshot'
+rm -f /tmp/flameshot_armhf.deb
 

--- a/apps/Flameshot/install-64
+++ b/apps/Flameshot/install-64
@@ -7,8 +7,8 @@ function error {
   exit 1
 }
 
-rm -f flameshot_arm64.deb
-wget -O flameshot_arm64.deb https://github.com/chunky-milk/raspbian-addons/raw/master/debian/pool/main/f/flameshot/flameshot_0.9.0-1_arm64.deb || error 'Failed to download Flameshot deb file'
-sudo apt install ./flameshot_arm64.deb -yf || error 'Failed to install flameshot'
-rm -f flameshot_arm64.deb
+rm -f /tmp/flameshot_arm64.deb
+wget -O /tmp/flameshot_arm64.deb https://github.com/chunky-milk/raspbian-addons/raw/master/debian/pool/main/f/flameshot/flameshot_0.9.0-1_arm64.deb || error 'Failed to download Flameshot deb file'
+sudo apt install /tmp/flameshot_arm64.deb -yf || error 'Failed to install flameshot'
+rm -f /tmp/flameshot_arm64.deb
 


### PR DESCRIPTION
Just means it gets wiped on reboot if the rm fails for any reason