### PR TITLE
Update snapdrop links

### DIFF
--- a/apps/Snapdrop/install-32
+++ b/apps/Snapdrop/install-32
@@ -8,7 +8,7 @@ function error {
 
 rm -f snapdrop-linux-armv7l.tar.xz
 
-wget https://github.com/chunky-milk/snapdrop-rpi/releases/download/1.0/snapdrop-linux-armv7l.tar.xz || error "Failed to download archive!"
+wget https://github.com/chunky-milk/snapdrop-rpi/releases/download/2.0/Snapdrop-linux-armv7l.tar.xz || error "Failed to download archive!"
 tar -xvf snapdrop-linux-armv7l.tar.xz || error "Failed to extract archive!"
 rm -f snapdrop-linux-armv7l.tar.xz
 

--- a/apps/Snapdrop/install-64
+++ b/apps/Snapdrop/install-64
@@ -6,12 +6,11 @@ function error {
   exit 1
 }
 
-rm -f snapdrop-linux-arm64.zip
+rm -f Snapdrop-linux-arm64.zip
 
-wget https://github.com/chunky-milk/snapdrop-rpi/releases/download/1.0/snapdrop-linux-arm64.zip || error "Failed to download archive!"
-unzip snapdrop-linux-arm64.zip || error "Failed to extract archive!"
-rm -f snapdrop-linux-arm64.zip || error "Failed to remove archive!"
-mv Snapdrop-linux-arm64 snapdrop
+wget https://github.com/chunky-milk/snapdrop-rpi/releases/download/2.0/Snapdrop-linux-arm64.zip || error "Failed to download archive!"
+unzip Snapdrop-linux-arm64.zip || error "Failed to extract archive!"
+rm -f Snapdrop-linux-arm64.zip || error "Failed to remove archive!"
 
 # Desktop entry
 echo "[Desktop Entry]


### PR DESCRIPTION
This release *should* fix "Old build detected" error