### PR TITLE
make pikiss a 32bit app only

### DIFF
--- a/apps/piKiss/install-32
+++ b/apps/piKiss/install-32
@@ -7,8 +7,4 @@ function error {
   exit 1
 }
 
-#use the error function often!
-#If a certain command is necessary for installation to continue, then add this to the end of it:
-# || error 'reason'
-#example below:
 curl -sSL https://git.io/JfAPE | bash || error 'Failed to install piKiss!'


### PR DESCRIPTION
PiKiss only supports 32bit OS's, so I renamed its `install` script to `install-32`