### PR TITLE
Fix remarkable 64bit install script

### DIFF
--- a/apps/Remarkable/install-64
+++ b/apps/Remarkable/install-64
@@ -14,16 +14,12 @@ wget http://ftp.br.debian.org/debian/pool/main/w/webkitgtk/libjavascriptcoregtk-
 wget http://ftp.br.debian.org/debian/pool/main/i/icu/libicu57_57.1-6+deb9u4_arm64.deb || error 'Failed to Download libicu57'
 wget http://ftp.br.debian.org/debian/pool/main/w/webkitgtk/libwebkitgtk-3.0-0_2.4.11-3_arm64.deb || error 'Failed to download libwebkitgtk'
 wget http://ftp.br.debian.org/debian/pool/main/w/webkitgtk/gir1.2-javascriptcoregtk-3.0_2.4.11-3_arm64.deb || error 'Failed to download gir1.2-javascriptcoregtk'
+wget http://ftp.br.debian.org/debian/pool/main/e/enchant/libenchant1c2a_1.6.0-11.1+b1_arm64.deb || error 'Failed to download libenchant1c2a'
+wget http://ftp.br.debian.org/debian/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_arm64.deb || error 'Failed to download libjpeg62-turbo'
 
 
 #installation
-"${DIRECTORY}/pkg-install" ~/libicu57_57.1-6+deb9u4_arm64.deb "$(dirname "$0")" || error 'Failed to install libicu57_57.1-6+deb9u4_arm64'
-"${DIRECTORY}/pkg-install" ~/libjavascriptcoregtk-3.0-0_2.4.11-3_arm64.deb "$(dirname "$0")" || error 'Failed to install libjavascriptcoregtk-3.0-0_2.4.11-3_arm64'
-"${DIRECTORY}/pkg-install" ~/libwebkitgtk-3.0-0_2.4.11-3_arm64.deb "$(dirname "$0")" || error 'Failed to install libwebkitgtk-3.0-0_2.4.11-3_arm64'
-"${DIRECTORY}/pkg-install" ~/gir1.2-javascriptcoregtk-3.0_2.4.11-3_arm64.deb "$(dirname "$0")" || error 'Failed to install libjavascriptcoregtk-3.0-0_2.4.11-3_arm64'
-
-"${DIRECTORY}/pkg-install" ~/gir1.2-webkit-3.0_2.4.11-3_arm64.deb "$(dirname "$0")" || error 'Failed to install gir1.2-webkit-3.0_2.4.11-3_arm64'
-"${DIRECTORY}/pkg-install" ~/remarkable_1.87_all.deb "$(dirname "$0")" || error 'Failed to install remarkable_1.87_all'
+"${DIRECTORY}/pkg-install" "$(pwd)/gir1.2-webkit-3.0_2.4.11-3_arm64.deb $(pwd)/gir1.2-javascriptcoregtk-3.0_2.4.11-3_arm64.deb $(pwd)/libwebkitgtk-3.0-0_2.4.11-3_arm64.deb $(pwd)/libjavascriptcoregtk-3.0-0_2.4.11-3_arm64.deb $(pwd)/libenchant1c2a_1.6.0-11.1+b1_arm64.deb $(pwd)/libjpeg62-turbo_2.0.6-4_arm64.deb $(pwd)/libicu57_57.1-6+deb9u4_arm64.deb $(pwd)/remarkable_1.87_all.deb" "$(dirname "$0")" || error 'Failed to install libicu57_57.1-6+deb9u4_arm64'
 
 #remove
 rm -f remarkable_1.87_all.deb
@@ -32,3 +28,5 @@ rm -f libwebkitgtk-3.0-0_2.4.11-3_arm64.deb
 rm -f libjavascriptcoregtk-3.0-0_2.4.11-3_arm64.deb
 rm -f gir1.2-javascriptcoregtk-3.0_2.4.11-3_arm64.deb
 rm -f libicu57_57.1-6+deb9u4_arm64.deb
+rm -f libjpeg62-turbo_2.0.6-4_arm64.deb
+rm -f libenchant1c2a_1.6.0-11.1+b1_arm64.deb

--- a/apps/Remarkable/install-64
+++ b/apps/Remarkable/install-64
@@ -7,6 +7,9 @@ function error {
   exit 1
 }
 
+#I know the the manage script already does this, but I don't feel comfortable not adding this - Itai
+cd "$HOME"
+
 #downloads
 wget https://remarkableapp.github.io/files/remarkable_1.87_all.deb || error 'Failed to Download remarkable_1.87_all'
 wget http://ftp.br.debian.org/debian/pool/main/w/webkitgtk/gir1.2-webkit-3.0_2.4.11-3_arm64.deb || error 'Failed to Download gir1.2-webkit-3.0'
@@ -19,7 +22,7 @@ wget http://ftp.br.debian.org/debian/pool/main/libj/libjpeg-turbo/libjpeg62-turb
 
 
 #installation
-"${DIRECTORY}/pkg-install" "$(pwd)/gir1.2-webkit-3.0_2.4.11-3_arm64.deb $(pwd)/gir1.2-javascriptcoregtk-3.0_2.4.11-3_arm64.deb $(pwd)/libwebkitgtk-3.0-0_2.4.11-3_arm64.deb $(pwd)/libjavascriptcoregtk-3.0-0_2.4.11-3_arm64.deb $(pwd)/libenchant1c2a_1.6.0-11.1+b1_arm64.deb $(pwd)/libjpeg62-turbo_2.0.6-4_arm64.deb $(pwd)/libicu57_57.1-6+deb9u4_arm64.deb $(pwd)/remarkable_1.87_all.deb" "$(dirname "$0")" || error 'Failed to install libicu57_57.1-6+deb9u4_arm64'
+"${DIRECTORY}/pkg-install" "$(HOME)/gir1.2-webkit-3.0_2.4.11-3_arm64.deb $(HOME)/gir1.2-javascriptcoregtk-3.0_2.4.11-3_arm64.deb $(HOME)/libwebkitgtk-3.0-0_2.4.11-3_arm64.deb $(HOME)/libjavascriptcoregtk-3.0-0_2.4.11-3_arm64.deb $(HOME)/libenchant1c2a_1.6.0-11.1+b1_arm64.deb $(HOME)/libjpeg62-turbo_2.0.6-4_arm64.deb $(HOME)/libicu57_57.1-6+deb9u4_arm64.deb $(HOME)/remarkable_1.87_all.deb" "$(dirname "$0")" || error 'Failed to install libicu57_57.1-6+deb9u4_arm64'
 
 #remove
 rm -f remarkable_1.87_all.deb


### PR DESCRIPTION
# Not ready for merging yet
Installs successfully, but remarkable fails to start. tested on a fresh install of Ubuntu 21.04 desktop.

- added 2 missing dependencies.
- install all the packages in a single `pkg-install` line to prevent uninstalling the dummy deb for each dependency so at the end only the last package is installed.
- The fix in 3390bcec32e0b12b5c2c18a7c47b127ed688611b didn't work, so I changed it to `$(pwd)/xxx.deb` instead of `~/xxx.deb`.