### PR TITLE
Update Etcher to v1.5.120

### DIFF
--- a/apps/BalenaEtcher/install-32
+++ b/apps/BalenaEtcher/install-32
@@ -7,7 +7,7 @@ function error {
   exit 1
 }
 
-rm -f ./etcher*armv7l.deb
+rm -f ./etcher.deb
 
 wget -O ~/etcher.deb https://github.com/Itai-Nelken/Etcher-arm-32-64/releases/download/v1.5.120/balena-etcher_1.5.120_armv7l.deb || error "Failed to download etcher deb file!"
 

--- a/apps/BalenaEtcher/install-32
+++ b/apps/BalenaEtcher/install-32
@@ -9,8 +9,8 @@ function error {
 
 rm -f ./etcher*armv7l.deb
 
-wget https://github.com/Itai-Nelken/Etcher-arm-32-64/releases/download/v1.5.117/balena-etcher-electron_1.5.117+39ccbbee_armhf.deb -O ~/etcher-v1.5.117_armv7l.deb || error "Failed to download!"
+wget -O ~/etcher.deb https://github.com/Itai-Nelken/Etcher-arm-32-64/releases/download/v1.5.120/balena-etcher_1.5.120_armv7l.deb || error "Failed to download etcher deb file!"
 
-sudo apt install -fy ~/etcher-v1.5.117_armv7l.deb  || error "failed to install deb file!"
-rm -f ~/etcher-v1.5.117_armv7l.deb
+sudo apt install -fy ~/etcher.deb  || error "failed to install deb file!"
+rm -f ~/etcher.deb
 exit 0

--- a/apps/BalenaEtcher/install-64
+++ b/apps/BalenaEtcher/install-64
@@ -9,11 +9,11 @@ function error {
   exit 1
 }
 
-rm -f ~/etcher*arm64.deb
+rm -f ~/etcher.deb
 
-wget https://github.com/Itai-Nelken/Etcher-arm-32-64/releases/download/v1.5.117/balena-etcher-electron_1.5.117+39ccbbee_arm64.deb -O ~/etcher-v1.5.117_arm64.deb || error "Failed to download!"
+wget -O ~/etcher.deb https://github.com/Itai-Nelken/Etcher-arm-32-64/releases/download/v1.5.120/balena-etcher_1.5.120_arm64.deb || error "Failed to download etcher deb file!"
 
-sudo apt install -fy ~/etcher-v1.5.117_arm64.deb || error "failed to install deb file!"
-rm -f ~/etcher-v1.5.117_arm64.deb
+sudo apt install -fy ~/etcher.deb || error "failed to install deb file!"
+rm -f ~/etcher.deb
 
 exit 0

--- a/apps/BalenaEtcher/uninstall
+++ b/apps/BalenaEtcher/uninstall
@@ -6,7 +6,8 @@ function error {
   echo -e "\\e[91m$1\\e[39m"
   exit 1
 }
-
-sudo apt purge -y balena-etcher-electron || error "failed to purge the deb file!"
+# Old deb file name, commented out
+# sudo apt purge -y balena-etcher-electron
+sudo apt purge -y balena-etcher -y || error "Failed to purge deb!"
 rm -f ~/etcher.deb &>/dev/null
 exit 0


### PR DESCRIPTION
also note that the deb name is now `balena-etcher` and not `balena-etcher-electron`.