### PR TITLE
Set upstream server in lokinet.ini

### DIFF
--- a/apps/Lokinet/install
+++ b/apps/Lokinet/install
@@ -40,6 +40,7 @@ fi
 
 echo "Updating resolvconf and starting lokinet service..."
 sudo resolvconf -u
+sudo sed '/upstream/s/^#//' -i /etc/loki/lokinet.ini || error "Failed to set upstream resolver"
 sudo systemctl restart lokinet || error "Systemd failed to restart the lokinet service!"
  
 echo "Installation complete!"


### PR DESCRIPTION
Changes in lokinet dns settings require upstream server value to be provided.