### PR TITLE
Don't use cache for MCPI

### DIFF
--- a/apps/Minecraft Pi (Modded)/install
+++ b/apps/Minecraft Pi (Modded)/install
@@ -32,7 +32,7 @@ done
 # Remove old MCPILs
 sudo apt-get remove -y mcpil-r mcpil &>/dev/null || true
 
-wget -q -O - https://raw.githubusercontent.com/MCPI-Revival/mcpi-packages/master/install.sh | sudo bash - || error "Failed to install APT repo!"
+wget --no-cache -q -O - https://raw.githubusercontent.com/MCPI-Revival/mcpi-packages/master/install.sh | sudo bash - || error "Failed to install APT repo!"
 
 # Choose MCPIL to use
 PS3="Which launcher for MCPI Modded would you like to use? Need help deciding? Ask here: https://discord.com/invite/aDqejQGMMy


### PR DESCRIPTION
Yet another small fix for MCPI: tell `wget` to not use the cached version of the remote MCPI-Packages install script.