### PR TITLE
Use `pkg-install` in Mac OS Theme

### DIFF
--- a/apps/Mac OS Theme/install-32
+++ b/apps/Mac OS Theme/install-32
@@ -7,6 +7,10 @@ function error {
   exit 1
 }
 
+# Get dependencies
+"${DIRECTORY}/pkg-install" "compton plank xfwm4 xfce4-settings nautilus yad xfce4-panel xfce4-appmenu-plugin xfce4-statusnotifier-plugin xfce4-pulseaudio-plugin blueman figlet lolcat python-pil.imagetk python3-pil python3-pil.imagetk network-manager network-manager-gnome" "$(dirname "$0")" || exit 1
+
+
 rm -rf ~/MacOSBigSurThemeConverter || error "Failed to first remove ~/MacOSBigSurThemeConverter folder"
 git clone https://github.com/techcoder20/MacOSBigSurThemeConverter.git || error "failed to download github repository!"
 


### PR DESCRIPTION
I added all the dependencies that are installed using apt but some dependencies are there where i manually download the deb and install it. I have seen deb files used with `pkg-install` but as it is running before the whole install scripts those debs wont be there. If you want I can only download and install those debs using the pi apps install script so that I can make use of `pkg-install`.