### PR TITLE
Fix some WhatsApp issue

### DIFF
--- a/apps/Whatsapp/install-32
+++ b/apps/Whatsapp/install-32
@@ -14,7 +14,7 @@ tar -xf WhatsApp-linux-armv7l.tar.xz || error "Failed to extract!"
 rm WhatsApp-linux-armv7l.tar.xz
 mv "WhatsApp-linux-armv7l" WhatsApp
 
-#Modify run-whatsapp
+#Modify run-whatsapp to remove Service Worker before launching WhatsApp
 echo "rm -rf $HOME/.config/whats*/Service* && $HOME/WhatsApp/WhatsApp" > WhatsApp/run-whatsapp
 
 #create menu shortcut
@@ -22,5 +22,5 @@ echo "[Desktop Entry]
 Name=WhatsApp
 Type=Application
 Exec=bash /home/pi/WhatsApp/run-whatsapp
-Icon=/home/pi/WhatsApp/resources/app/icon.png
+Icon=$(dirname "$0")/icon-64.png
 Categories=Network;Internet" >  ~/.local/share/applications/whatsapp.desktop || error "Failed to create menu button!"

--- a/apps/Whatsapp/install-32
+++ b/apps/Whatsapp/install-32
@@ -12,10 +12,12 @@ rm -f WhatsApp-linux-armv7l.tar.xz
 wget https://github.com/cycool29/whatsapp-for-linux/releases/download/rpi-v1.0/WhatsApp-linux-armv7l.tar.xz || error 'Failed to download!'
 tar -xf WhatsApp-linux-armv7l.tar.xz || error "Failed to extract!"
 rm WhatsApp-linux-armv7l.tar.xz
-mv "WhatsAppWeb-linux-armv7l" WhatsApp
+mv "WhatsApp-linux-armv7l" WhatsApp
 
 #create menu shortcut
-wget https://github.com/cycool29/whatsapp-for-linux/releases/download/rpi-v1.0/whatsapp.desktop 
-sed -i "s@HOME@$HOME@g" whatsapp.desktop 
-sudo cp whatsapp.desktop .local/share/applications 
-sudo cp whatsapp.desktop $HOME/Desktop
+echo "[Desktop Entry]
+Name=WhatsApp
+Type=Application
+Exec=/home/pi/WhatsApp/run-whatsapp
+Icon=/home/pi/WhatsApp/resources/app/icon.png
+Categories=Network;Internet" >  ~/.local/share/applications/whatsapp.desktop || error "Failed to create menu button!"

--- a/apps/Whatsapp/install-32
+++ b/apps/Whatsapp/install-32
@@ -21,6 +21,6 @@ echo "rm -rf $HOME/.config/whats*/Service* && $HOME/WhatsApp/WhatsApp" WhatsApp/
 echo "[Desktop Entry]
 Name=WhatsApp
 Type=Application
-Exec=/home/pi/WhatsApp/run-whatsapp
+Exec=bash /home/pi/WhatsApp/run-whatsapp
 Icon=/home/pi/WhatsApp/resources/app/icon.png
 Categories=Network;Internet" >  ~/.local/share/applications/whatsapp.desktop || error "Failed to create menu button!"

--- a/apps/Whatsapp/install-32
+++ b/apps/Whatsapp/install-32
@@ -8,7 +8,7 @@ function error {
 }
 
 cd $HOME
-rm -f WhatsAppWeb-linux-armv7l.tar.xz
+rm -f WhatsApp-linux-armv7l.tar.xz
 wget https://github.com/cycool29/whatsapp-for-linux/releases/download/rpi-v1.0/WhatsApp-linux-armv7l.tar.xz || error 'Failed to download!'
 tar -xf WhatsApp-linux-armv7l.tar.xz || error "Failed to extract!"
 rm WhatsApp-linux-armv7l.tar.xz

--- a/apps/Whatsapp/install-32
+++ b/apps/Whatsapp/install-32
@@ -14,6 +14,9 @@ tar -xf WhatsApp-linux-armv7l.tar.xz || error "Failed to extract!"
 rm WhatsApp-linux-armv7l.tar.xz
 mv "WhatsApp-linux-armv7l" WhatsApp
 
+#Modify run-whatsapp
+echo "rm -rf $HOME/.config/whats*/Service* && $HOME/WhatsApp/WhatsApp" WhatsApp/run-whatsapp
+
 #create menu shortcut
 echo "[Desktop Entry]
 Name=WhatsApp

--- a/apps/Whatsapp/install-32
+++ b/apps/Whatsapp/install-32
@@ -15,7 +15,7 @@ rm WhatsApp-linux-armv7l.tar.xz
 mv "WhatsApp-linux-armv7l" WhatsApp
 
 #Modify run-whatsapp
-echo "rm -rf $HOME/.config/whats*/Service* && $HOME/WhatsApp/WhatsApp" WhatsApp/run-whatsapp
+echo "rm -rf $HOME/.config/whats*/Service* && $HOME/WhatsApp/WhatsApp" > WhatsApp/run-whatsapp
 
 #create menu shortcut
 echo "[Desktop Entry]

--- a/apps/Whatsapp/install-32
+++ b/apps/Whatsapp/install-32
@@ -7,20 +7,21 @@ function error {
   exit 1
 }
 
-cd $HOME
-rm -f WhatsApp-linux-armv7l.tar.xz
-wget https://github.com/cycool29/whatsapp-for-linux/releases/download/rpi-v1.0/WhatsApp-linux-armv7l.tar.xz || error 'Failed to download!'
-tar -xf WhatsApp-linux-armv7l.tar.xz || error "Failed to extract!"
-rm WhatsApp-linux-armv7l.tar.xz
-mv "WhatsApp-linux-armv7l" WhatsApp
+rm -rf ~/whatsapp.tar.xz ~/WhatsApp
+mkdir ~/WhatsApp
 
-#Modify run-whatsapp to remove Service Worker before launching WhatsApp
-echo "rm -rf $HOME/.config/whats*/Service* && $HOME/WhatsApp/WhatsApp" > WhatsApp/run-whatsapp
+wget -O ~/whatsapp.tar.xz https://github.com/cycool29/whatsapp-for-linux/releases/download/rpi-v1.0/WhatsApp-linux-armv7l.tar.xz || error 'Failed to download!'
+tar -xf ~/whatsapp.tar.xz -C ~/WhatsApp || error "Failed to extract!"
+rm ~/whatsapp.tar.xz
+mv ~/WhatsApp/WhatsApp-linux-armv7l/* ~/WhatsApp && rm -rf ~/WhatsApp/WhatsApp-linux-armv7l
 
 #create menu shortcut
 echo "[Desktop Entry]
 Name=WhatsApp
-Type=Application
-Exec=bash /home/pi/WhatsApp/run-whatsapp
+Exec=bash -c "\""rm -rf $HOME/.config/whats*/Service* ; $HOME/WhatsApp/WhatsApp"\""
+Path=$HOME/WhatsApp
 Icon=$(dirname "$0")/icon-64.png
-Categories=Network;Internet" >  ~/.local/share/applications/whatsapp.desktop || error "Failed to create menu button!"
+Terminal=false
+StartupNotify=true
+Type=Application
+Categories=Network;" > ~/.local/share/applications/whatsapp.desktop || error "Failed to create menu button!"

--- a/apps/Whatsapp/install-32
+++ b/apps/Whatsapp/install-32
@@ -9,19 +9,13 @@ function error {
 
 cd $HOME
 rm -f WhatsAppWeb-linux-armv7l.tar.xz
-wget https://github.com/Itai-Nelken/Nativefier-WebApps/releases/download/v3.0/WhatsAppWeb-linux-armv7l.tar.xz || error 'Failed to download!'
-tar -xf WhatsAppWeb-linux-armv7l.tar.xz || error "Failed to extract!"
-rm WhatsAppWeb-linux-armv7l.tar.xz
-mv "WhatsAppWeb-linux-armv7l" WhatsAppWeb
+wget https://github.com/cycool29/whatsapp-for-linux/releases/download/rpi-v1.0/WhatsApp-linux-armv7l.tar.xz || error 'Failed to download!'
+tar -xf WhatsApp-linux-armv7l.tar.xz || error "Failed to extract!"
+rm WhatsApp-linux-armv7l.tar.xz
+mv "WhatsAppWeb-linux-armv7l" WhatsApp
 
 #create menu shortcut
-echo "[Desktop Entry]
-Name=Whatsapp Web
-Comment=Nativefier Whatsapp Web webapp.
-Exec=$HOME/WhatsAppWeb/WhatsAppWeb
-Path=$HOME/WhatsAppWeb
-Icon=$(dirname "$0")/icon-64.png
-Terminal=false
-StartupNotify=true
-Type=Application
-Categories=Network;" > ~/.local/share/applications/whatsappweb.desktop || error "Failed to create menu button!"
+wget https://github.com/cycool29/whatsapp-for-linux/releases/download/rpi-v1.0/whatsapp.desktop 
+sed -i "s@HOME@$HOME@g" whatsapp.desktop 
+sudo cp whatsapp.desktop .local/share/applications 
+sudo cp whatsapp.desktop $HOME/Desktop

--- a/apps/Whatsapp/install-64
+++ b/apps/Whatsapp/install-64
@@ -8,20 +8,19 @@ function error {
 }
 
 cd $HOME
-rm -f WhatsAppWeb-linux-arm64.tar.xz
-wget https://github.com/Itai-Nelken/Nativefier-WebApps/releases/download/v3.0/WhatsAppWeb-linux-arm64.tar.xz || error 'Failed to download!'
-tar -xf WhatsAppWeb-linux-arm64.tar.xz || error "Failed to extract!"
-rm WhatsAppWeb-linux-arm64.tar.xz
-mv "WhatsAppWeb-linux-arm64" WhatsAppWeb
+rm -f WhatsApp-linux-arm64.tar.xz
+wget https://github.com/cycool29/whatsapp-for-linux/releases/download/rpi-arm64-1.0/WhatsApp-linux-arm64.tar.xz || error 'Failed to download!'
+tar -xf WhatsApp-linux-arm64.tar.xz || error "Failed to extract!"
+rm WhatsApp-linux-arm64.tar.xz
+mv "WhatsApp-linux-arm64" WhatsApp
+
+#Modify run-whatsapp to remove Service Worker before launching WhatsApp
+echo "rm -rf $HOME/.config/whats*/Service* && $HOME/WhatsApp/WhatsApp" > WhatsApp/run-whatsapp
 
 #create menu shortcut
 echo "[Desktop Entry]
-Name=Whatsapp Web
-Comment=Nativefier Whatsapp Web webapp.
-Exec=$HOME/WhatsAppWeb/WhatsAppWeb
-Path=$HOME/WhatsAppWeb
-Icon=$(dirname "$0")/icon-64.png
-Terminal=false
-StartupNotify=true
+Name=WhatsApp
 Type=Application
-Categories=Network;" > ~/.local/share/applications/whatsappweb.desktop || error "Failed to create menu button!"
+Exec=bash /home/pi/WhatsApp/run-whatsapp
+Icon=$(dirname "$0")/icon-64.png
+Categories=Network;Internet" >  ~/.local/share/applications/whatsapp.desktop || error "Failed to create menu button!"

--- a/apps/Whatsapp/install-64
+++ b/apps/Whatsapp/install-64
@@ -7,20 +7,21 @@ function error {
   exit 1
 }
 
-cd $HOME
-rm -f WhatsApp-linux-arm64.tar.xz
-wget https://github.com/cycool29/whatsapp-for-linux/releases/download/rpi-arm64-1.0/WhatsApp-linux-arm64.tar.xz || error 'Failed to download!'
-tar -xf WhatsApp-linux-arm64.tar.xz || error "Failed to extract!"
-rm WhatsApp-linux-arm64.tar.xz
-mv "WhatsApp-linux-arm64" WhatsApp
+rm -rf ~/whatsapp.tar.xz ~/WhatsApp
+mkdir ~/WhatsApp
 
-#Modify run-whatsapp to remove Service Worker before launching WhatsApp
-echo "rm -rf $HOME/.config/whats*/Service* && $HOME/WhatsApp/WhatsApp" > WhatsApp/run-whatsapp
+wget -O ~/whatsapp.tar.xz https://github.com/cycool29/whatsapp-for-linux/releases/download/rpi-arm64-1.0/WhatsApp-linux-arm64.tar.xz || error 'Failed to download!'
+tar -xf ~/whatsapp.tar.xz -C ~/WhatsApp || error "Failed to extract!"
+rm ~/whatsapp.tar.xz
+mv ~/WhatsApp/WhatsApp-linux-armv7l/* ~/WhatsApp && rm -rf ~/WhatsApp/WhatsApp-linux-armv7l
 
 #create menu shortcut
 echo "[Desktop Entry]
 Name=WhatsApp
-Type=Application
-Exec=bash /home/pi/WhatsApp/run-whatsapp
+Exec=bash -c "\""rm -rf $HOME/.config/whats*/Service* ; $HOME/WhatsApp/WhatsApp"\""
+Path=$HOME/WhatsApp
 Icon=$(dirname "$0")/icon-64.png
-Categories=Network;Internet" >  ~/.local/share/applications/whatsapp.desktop || error "Failed to create menu button!"
+Terminal=false
+StartupNotify=true
+Type=Application
+Categories=Network;" > ~/.local/share/applications/whatsapp.desktop || error "Failed to create menu button!"

--- a/apps/Whatsapp/uninstall
+++ b/apps/Whatsapp/uninstall
@@ -12,7 +12,8 @@ rm -rf ~/WhatsappWeb
 
 #for backwards compatibility with Itai's version
 rm -rf ~/WhatsAppWeb
+rm -f ~/.local/share/applications/whatsappweb.desktop
 
 rm -rf ~/WhatsApp
-rm ~/.local/share/applications/whatsapp.desktop
+rm -f ~/.local/share/applications/whatsapp.desktop
 exit 0

--- a/apps/Whatsapp/uninstall
+++ b/apps/Whatsapp/uninstall
@@ -7,9 +7,9 @@ function error {
   exit 1
 }
 
-#for backwards compatibility with the chromium version
-rm -rf ~/WhatsappWeb &>/dev/null
+# for backwards compatibility with the chromium version
+# rm -rf ~/Whatsapp &>/dev/null
 
-rm -rf ~/WhatsAppWeb
-rm ~/.local/share/applications/whatsappweb.desktop
+rm -rf ~/WhatsApp
+rm ~/.local/share/applications/whatsapp.desktop
 exit 0

--- a/apps/Whatsapp/uninstall
+++ b/apps/Whatsapp/uninstall
@@ -7,8 +7,11 @@ function error {
   exit 1
 }
 
-# for backwards compatibility with the chromium version
-# rm -rf ~/Whatsapp &>/dev/null
+#for backwards compatibility with the chromium version
+rm -rf ~/WhatsappWeb
+
+#for backwards compatibility with Itai's version
+rm -rf ~/WhatsAppWeb
 
 rm -rf ~/WhatsApp
 rm ~/.local/share/applications/whatsapp.desktop


### PR DESCRIPTION
- Built with latest nativefier to solve `Old build detected` warning.

- Fix `To use WhatsApp, update Chrome or use Mozilla Firefox, Safari, Microsoft Edge or Opera.` by deleting service worker every time when WhatsApp launch. I know there are several JS injection solution on the web but they are often not working. 

**NOTE**: The service worker fix tested works perfectly in **normal version WhatsApp** but in **Multi-device beta** it will show a prompt like this:

![update_available](https://user-images.githubusercontent.com/88134003/134290969-d6d6803a-0519-4dfd-a166-62b21d296c33.png)

Still exploring for fix of this bug...
