### PR TITLE
Fix reduceapt not working on sudo apt update in `pkg-install`

### DIFF
--- a/pkg-install
+++ b/pkg-install
@@ -234,7 +234,7 @@ apt_lock_wait
 #sudo apt update
 {
 echo -e "Running \e[4msudo a\e[0mp\e[4mt u\e[0mp\e[4mdate\e[0m..."
-output="$(sudo -E apt update --allow-releaseinfo-change 2>&1 | tee /dev/stderr | reduceapt)"
+output="$(sudo -E apt update --allow-releaseinfo-change 2>&1 | reduceapt | tee /dev/stderr)"
 exitcode=$?
 
 #inform user about autoremovable packages


### PR DESCRIPTION
Just `reduceapt` first before `tee` to `/dev/stderr`.