### PR TITLE
Use Nodesource to install Node.js

### DIFF
--- a/apps/Node.js/install
+++ b/apps/Node.js/install
@@ -24,8 +24,8 @@ export NVM_DIR="$HOME/.nvm"
 mkdir -p "$NVM_DIR"
 wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash || error "Failed to install nvm!"
 
-#determine if host system is 64 bit arm64 or 32 bit armhf
-if [ ! -z "$(file "$(readlink -f "/sbin/init")" | grep 32)" ];then
+source "${DIRECTORY}/api"
+if [ "$arch" == 32 ];then
   #armhf, so patch nvm script to forcibly use armhf
   sed -i 's/^  nvm_echo "${NVM_ARCH}"/  NVM_ARCH=armv7l ; nvm_echo "${NVM_ARCH}"/g' "$NVM_DIR/nvm.sh"
 fi

--- a/apps/Node.js/install
+++ b/apps/Node.js/install
@@ -9,10 +9,10 @@ function error {
 
 # Uninstall nodejs, node and npm from other sources first
 echo "Uninstall nodejs, node and npm from other sources first ..."
-sudo snap remove node --purge > /dev/null
-sudo rm -rf $NVM_DIR ~/.npm ~/.bower > /dev/null
-sed -i '/NVM_DIR/d' ~/.bashrc  > /dev/null
-sudo apt purge node npm nodejs -y  > /dev/null # I can't find a script in pi-apps to uninstall package in installation script 
+sudo snap remove node --purge 2&> /dev/null
+sudo rm -rf $NVM_DIR ~/.npm ~/.bower 2&> /dev/null
+sed -i '/NVM_DIR/d' ~/.bashrc  2&> /dev/null
+sudo apt purge node npm nodejs -y  2&> /dev/null
 
 # Add Nodesource  apt key 
 ( curl -fsSL https://deb.nodesource.com/setup_current.x | sudo -E bash - ) || error "Failed adding nodesource keyring!"

--- a/apps/Node.js/install
+++ b/apps/Node.js/install
@@ -8,7 +8,7 @@ function error {
 }
 
 # Uninstall nodejs, node and npm from other sources first
-echo "Uninstall nodejs, node and npm from other sources first ..."
+echo "Uninstalling Nodejs, node and npm from other sources first ..."
 sudo snap remove node --purge 2&> /dev/null
 sudo rm -rf $NVM_DIR ~/.npm ~/.bower 2&> /dev/null
 sed -i '/NVM_DIR/d' ~/.bashrc  2&> /dev/null

--- a/apps/Node.js/install
+++ b/apps/Node.js/install
@@ -7,15 +7,54 @@ function error {
   exit 1
 }
 
-# Uninstall nodejs, node and npm from other sources first
-echo "Uninstalling Nodejs, node and npm from other sources first ..."
-sudo snap remove node --purge 2&> /dev/null
-sudo rm -rf $NVM_DIR ~/.npm ~/.bower 2&> /dev/null
-sed -i '/NVM_DIR/d' ~/.bashrc  2&> /dev/null
-sudo apt purge node npm nodejs -y  2&> /dev/null
+#Checking if using armv6
+if [ ! -z "$(cat /proc/cpuinfo | grep ARMv6)" ];then
+  error "armv6 cpu not supported"
+fi
 
-# Add Nodesource  apt key 
-( curl -fsSL https://deb.nodesource.com/setup_current.x | sudo -E bash - ) || error "Failed adding nodesource keyring!"
+if ! command -v curl >/dev/null ; then
+  echo -e "\033[0;31mcurl: command not found.\e[39m
+You need to install curl first. If you are on a debian system, this command should install it:
+\e[4msudo apt install curl\e[0m"
+  exit 1
+fi
 
-# Install Node.js
-"${DIRECTORY}/pkg-install" "nodejs" "$(dirname "$0")" || error "Failed installing Node.js!"
+#Install nvm manager:
+export NVM_DIR="$HOME/.nvm"
+mkdir -p "$NVM_DIR"
+wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash || error "Failed to install nvm!"
+
+#determine if host system is 64 bit arm64 or 32 bit armhf
+if [ ! -z "$(file "$(readlink -f "/sbin/init")" | grep 32)" ];then
+  #armhf, so patch nvm script to forcibly use armhf
+  sed -i 's/^  nvm_echo "${NVM_ARCH}"/  NVM_ARCH=armv7l ; nvm_echo "${NVM_ARCH}"/g' "$NVM_DIR/nvm.sh"
+fi
+
+#remove original nvm stuff from bashrc
+sed -i '/NVM_DIR/d' ~/.bashrc
+
+# Create nvm initialisation script in another file for easier uninstallation
+# Credit: https://www.growingwiththeweb.com/2018/01/slow-nvm-init.html
+echo 'if [ -s "$HOME/.nvm/nvm.sh" ] && [ ! "$(type -t __init_nvm)" = function ]; then
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion"
+  declare -a __node_commands=("nvm" "node" "npm" "yarn" "gulp" "grunt" "webpack")
+  function __init_nvm() {
+    for i in "${__node_commands[@]}"; do unalias $i; done
+    . "$NVM_DIR"/nvm.sh
+    unset __node_commands
+    unset -f __init_nvm
+  }
+  for i in "${__node_commands[@]}"; do alias $i="__init_nvm && "$i; done
+fi' > ~/.node_bashrc
+
+echo ". ~/.node_bashrc" >> ~/.bashrc
+
+# One time use, since `source ~/.bashrc` not working
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+# Install latest nodejs
+nvm install node || error "Failed to install node.js with nvm!"
+

--- a/apps/Node.js/install
+++ b/apps/Node.js/install
@@ -7,33 +7,8 @@ function error {
   exit 1
 }
 
-#Checking if using armv6
-if [ ! -z "$(cat /proc/cpuinfo | grep ARMv6)" ];then
-  error "armv6 cpu not supported"
-fi
+# Add Nodesource keyring
+( curl -fsSL https://deb.nodesource.com/setup_current.x | sudo -E bash - ) || error "Failed adding nodesource keyring!"
 
-if ! command -v curl >/dev/null ; then
-  echo -e "\033[0;31mcurl: command not found.\e[39m
-You need to install curl first. If you are on a debian system, this command should install it:
-\e[4msudo apt install curl\e[0m"
-  exit 1
-fi
-
-#Install nvm manager:
-export NVM_DIR="$HOME/.nvm"
-mkdir -p "$NVM_DIR"
-wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash || error "Failed to install nvm!"
-
-#determine if host system is 64 bit arm64 or 32 bit armhf
-if [ ! -z "$(file "$(readlink -f "/sbin/init")" | grep 32)" ];then
-  #armhf, so patch nvm script to forcibly use armhf
-  sed -i 's/^  nvm_echo "${NVM_ARCH}"/  NVM_ARCH=armv7l ; nvm_echo "${NVM_ARCH}"/g' "$NVM_DIR/nvm.sh"
-fi
-
-chmod u+x "$NVM_DIR/nvm.sh" "$NVM_DIR/bash_completion"
-source "$NVM_DIR/nvm.sh" || error "Failed to source $NVM_DIR/nvm.sh"
-
-source "$NVM_DIR/bash_completion" || error "Failed to source $NVM_DIR/bash_completion"
-
-nvm install node || error "Failed to install node.js with nvm!"
-
+# Install Node.js
+"${DIRECTORY}/pkg-install" "nodejs" "$(dirname "$0")" || error "Failed installing Node.js!"

--- a/apps/Node.js/install
+++ b/apps/Node.js/install
@@ -7,7 +7,14 @@ function error {
   exit 1
 }
 
-# Add Nodesource keyring
+# Uninstall nodejs, node and npm from other sources first
+echo "Uninstall nodejs, node and npm from other sources first ..."
+sudo snap remove node --purge > /dev/null
+sudo rm -rf $NVM_DIR ~/.npm ~/.bower > /dev/null
+sed -i '/NVM_DIR/d' ~/.bashrc  > /dev/null
+sudo apt purge node npm nodejs -y  > /dev/null # I can't find a script in pi-apps to uninstall package in installation script 
+
+# Add Nodesource  apt key 
 ( curl -fsSL https://deb.nodesource.com/setup_current.x | sudo -E bash - ) || error "Failed adding nodesource keyring!"
 
 # Install Node.js

--- a/apps/Node.js/uninstall
+++ b/apps/Node.js/uninstall
@@ -9,8 +9,11 @@ function error {
 
 "${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
 
+# The `purge-installed` script seems unable to purge nodejs 
+sudo apt purge -y nodejs
+
 # Remove source list
-rm -fv /etc/apt/sources.list.d/nodesource*
+sudo rm -fv /etc/apt/sources.list.d/nodesource*
 
 # Remove nodesource apt key
-apt-key del 1655A0AB68576280
+sudo apt-key del 1655A0AB68576280

--- a/apps/Node.js/uninstall
+++ b/apps/Node.js/uninstall
@@ -10,10 +10,10 @@ function error {
 "${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
 
 # The `purge-installed` script seems unable to purge nodejs 
-sudo apt purge -y nodejs
+sudo apt purge -y nodejs || error "Failed purge Node.js!"
 
 # Remove source list
-sudo rm -fv /etc/apt/sources.list.d/nodesource*
+sudo rm -fv /etc/apt/sources.list.d/nodesource* || error "Failed remove nodesource source list!"
 
 # Remove nodesource apt key
-sudo apt-key del 1655A0AB68576280
+sudo apt-key del 1655A0AB68576280 || error "Failed delete Nodesource apt key!"

--- a/apps/Node.js/uninstall
+++ b/apps/Node.js/uninstall
@@ -7,13 +7,17 @@ function error {
   exit 1
 }
 
+reduceapt() { #remove unwanted lines from apt output
+  grep -v "apt does not have a stable CLI interface.\|Reading package lists...\|Building dependency tree\|Reading state information...\|Need to get\|After this operation,\|Get:\|Fetched\|Selecting previously unselected package\|Preparing to unpack\|Unpacking \|Setting up \|Processing triggers for "
+}
+
 "${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
 
 # The `purge-installed` script seems unable to purge nodejs 
-sudo apt purge -y nodejs || error "Failed purge Node.js!"
+sudo apt purge -y nodejs 2>&1 | reduceapt || error "Failed purge Node.js!" 
 
 # Remove source list
-sudo rm -fv /etc/apt/sources.list.d/nodesource* || error "Failed remove nodesource source list!"
+sudo rm -f /etc/apt/sources.list.d/nodesource* || error "Failed remove nodesource source list!"
 
 # Remove nodesource apt key
 sudo apt-key del 1655A0AB68576280 || error "Failed delete Nodesource apt key!"

--- a/apps/Node.js/uninstall
+++ b/apps/Node.js/uninstall
@@ -7,18 +7,10 @@ function error {
   exit 1
 }
 
-#prepare to run nvm
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-cd $NVM_DIR
+"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
 
-#Uninstall NodeJS
-nvm deactivate
-nvm uninstall default || error "Failed to purge Node.JS!"
+# Remove source list
+rm -fv /etc/apt/sources.list.d/nodesource*
 
-#Remove nvm
-sudo rm -rf "$NVM_DIR"
-
-#remove nvm stuff from bashrc
-sed -i '/NVM_DIR/d' ~/.bashrc
+# Remove nodesource apt key
+apt-key del 1655A0AB68576280

--- a/apps/Node.js/uninstall
+++ b/apps/Node.js/uninstall
@@ -21,7 +21,7 @@ nvm uninstall default || error "Failed to purge Node.JS!"
 sudo rm -rf "$NVM_DIR" ~/.npm ~/.bower
 
 # Remove nvm initialisation script
-sudo rm ~/.node_bashrc
+sudo rm -f  ~/.node_bashrc
 
 #remove nvm stuff from bashrc
 sed -i '/node_bashrc/d' ~/.bashrc

--- a/apps/Node.js/uninstall
+++ b/apps/Node.js/uninstall
@@ -7,17 +7,21 @@ function error {
   exit 1
 }
 
-reduceapt() { #remove unwanted lines from apt output
-  grep -v "apt does not have a stable CLI interface.\|Reading package lists...\|Building dependency tree\|Reading state information...\|Need to get\|After this operation,\|Get:\|Fetched\|Selecting previously unselected package\|Preparing to unpack\|Unpacking \|Setting up \|Processing triggers for "
-}
+#prepare to run nvm
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+cd $NVM_DIR
 
-"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
+#Uninstall NodeJS
+nvm deactivate
+nvm uninstall default || error "Failed to purge Node.JS!"
 
-# The `purge-installed` script seems unable to purge nodejs 
-sudo apt purge -y nodejs 2>&1 | reduceapt || error "Failed purge Node.js!" 
+#Remove nvm
+sudo rm -rf "$NVM_DIR" ~/.npm ~/.bower
 
-# Remove source list
-sudo rm -f /etc/apt/sources.list.d/nodesource* || error "Failed remove nodesource source list!"
+# Remove nvm initialisation script
+sudo rm ~/.node_bashrc
 
-# Remove nodesource apt key
-sudo apt-key del 1655A0AB68576280 || error "Failed delete Nodesource apt key!"
+#remove nvm stuff from bashrc
+sed -i '/node_bashrc/d' ~/.bashrc


### PR DESCRIPTION
Using `nvm` to install nodejs is terrible for me. It slowed down my terminal loading time (there are few issues about this: nvm-sh/nvm#1277, nvm-sh/nvm#1261). Although there are many solution on the web like editing `.bashrc`, modifying nvm install script, etc, I don't want to make it so confusing...

Then Nodesource does it **perfectly**. 
- It won't slow down terminal loading speed.
- It will make pi-apps easy to update Node.js with only changing the nodesource link, but with `nvm`, pi-apps will probably hard to update as it need to find out what version of nodejs user have, what is the latest version does nvm have, etc. 
- Also, Node.js from nodesource there is a [proper way](https://github.com/nodesource/distributions/issues/512) to uninstall with just `sudo apt purge nodejs` and remove source list and apt-key. On `nvm`, you will need to delete the folders one-by-one.

However, the [snap one](https://snapcraft.io/node) is also good, but I prefer nodesource since it don't have any dependencies.