### PR TITLE
Fix typo in Clam Antivirus install script

### DIFF
--- a/apps/Clam Antivirus/install
+++ b/apps/Clam Antivirus/install
@@ -10,7 +10,7 @@ function error {
 }
 
 wget -O ~/clamtk.deb 'https://github.com/dave-theunsub/clamtk/releases/download/v6.13/clamtk_6.13-1_all.deb' || error "Failed to download clamtk.deb"
-"${DIRECTORY}/pkg-install" "clamav $HOME.clamtk.deb" "$(dirname "$0")" || exit 1
+"${DIRECTORY}/pkg-install" "clamav $HOME/clamtk.deb" "$(dirname "$0")" || exit 1
 rm -f ~/clamtk.deb
 
 #if thunar file manager installed then also install clamtk thunar extension


### PR DESCRIPTION
Fix `dpkg-deb: error: failed to read archive '/home/pi.clamtk.deb': No such file or directory`