### PR TITLE
Fix typo in `pkg-install` script

### DIFF
--- a/pkg-install
+++ b/pkg-install
@@ -331,7 +331,7 @@ fi
 #mark ALL packages as autoremovable
 {
 for package in $PKG_LIST ;do
-  sudo -E apt-mark auto "$packagename" || error "pkg-install: failed to mark the $packagename package as autoremovable."
+  sudo -E apt-mark auto "$package" || error "pkg-install: failed to mark the $package package as autoremovable."
 done
 }
 


### PR DESCRIPTION
Fix `pkg-install: failed to mark the  package as autoremovable.` in few error reports.