### PR TITLE
Make sure to install libssl with git

### DIFF
--- a/install
+++ b/install
@@ -28,7 +28,7 @@ sudo rm -f /usr/share/applications/yad-icon-browser.desktop
 
 #install git
 if ! command -v git >/dev/null;then
-  sudo apt install -y git || error "Failed to install git."
+  sudo apt install -y git libssl-dev || error "Failed to install git."
 fi
 
 #install curl

--- a/install
+++ b/install
@@ -31,6 +31,13 @@ if ! command -v git >/dev/null;then
   sudo apt install -y git libssl-dev || error "Failed to install git."
 fi
 
+#remove libssl1.0-dev if it's installed to prevent git clone issues laster
+
+if [ $(dpkg-query -W -f='${Status}' libssl1.0-dev 2>/dev/null | grep -c "ok installed") -eq 1 ];
+then
+  sudo apt purge -y libssl1.0-dev
+fi
+
 #install curl
 if ! command -v curl >/dev/null;then
   sudo apt install -y curl || error "Failed to install curl."


### PR DESCRIPTION
Some users have libssl1.0-dev installed for some reason which breaks git cloning. Originally found this issue in https://discord.com/channels/770629697909424159/874656141475463229/893896367624294420 but I'm adding this to the install script itself just in case.