### PR TITLE
cli improvements

### DIFF
--- a/api
+++ b/api
@@ -256,7 +256,7 @@ script_name_cpu() { #get script name to run based on detected CPU arch
   
   #ensure $1 is valid app name
   if ! list_apps all | grep -q "$1" ;then
-    error "script_name_cpu: '$1' is an invalid app name."
+    error "script_name_cpu: '$1' is an invalid app name.\n"
   fi
   
   #this is used by the updater so we need to check the update folder too

--- a/api
+++ b/api
@@ -7,7 +7,7 @@ error() { #red text and exit 1
 }
 
 warning() { #yellow text
-  echo -e "\e[93m\e[5m 🔺\e[25m WARNING: $1"
+  echo -e "\e[93m\e[5m 🔺\e[25m WARNING: $1\e[0m"
 }
 
 status() { #cyan text to indicate what is happening

--- a/api
+++ b/api
@@ -2,20 +2,20 @@
 
 #informational functions below
 error() { #red text and exit 1
-  echo -e "\e[91m$1\e[39m" 1>&2
+  echo -e "\e[91m$1\e[0m" 1>&2
   exit 1
 }
 
 warning() { #yellow text
-  echo -e "\e[93m\e[5m🔺\e[25m WARNING: $1"
+  echo -e "\e[93m\e[5m 🔺\e[25m WARNING: $1"
 }
 
 status() { #cyan text to indicate what is happening
-  echo -e "\e[96m$1\e[39m"
+  echo -e "\e[96m$1\e[0m"
 }
 
 status_green() { #announce the success of a major action
-  echo -e "\e[92m$1\e[39m"
+  echo -e "\e[92m$1\e[0m"
 }
 #end of informational functions
 

--- a/manage
+++ b/manage
@@ -218,10 +218,10 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
     echo
     exit 0
   else
-    error "\nFailed to ${mode} ${app} with $scriptname script"\!"\e[39m
+    echo -e  "\n\e[91mFailed to ${mode} ${app} with $scriptname script"\!"\e[39m
 \e[40m\e[93m\e[5m▲\e[25m\e[39m \e[49m\e[93mNeed help? Copy the \e[1mENTIRE\e[0m\e[49m\e[93m terminal output or take a screenshot.
 Please ask on Github: \e[94m\e[4mhttps://github.com/Botspot/pi-apps/issues/new/choose\e[24m\e[93m
-Or on Discord: \e[94m\e[4mhttps://discord.gg/RXSTvaUvuu" | tee -a "$logfile"
+Or on Discord: \e[94m\e[4mhttps://discord.gg/RXSTvaUvuu\e[0m" | tee -a "$logfile"
     
     format_log_file "$logfile" #remove escape sequences from logfile
     mv "$logfile" "$(echo "$logfile" | sed 's+-incomplete-+-fail-+g')"
@@ -303,7 +303,7 @@ elif [ "$1" == 'update' ];then
   fi
   
   if [ "$failed" == 'true' ]; then
-    error "Failed to update ${app}."
+    echo -e "\e[91mFailed to update ${app}.\e[0m"
   else
     status_green "${app} was updated successfully."
   fi

--- a/manage
+++ b/manage
@@ -73,6 +73,8 @@ else
   supported=no
 fi
 
+
+
 if [ "$1" == 'multi-uninstall' ] || [ "$1" == 'multi-install' ];then
   
   if [ "$1" == 'multi-uninstall' ];then
@@ -80,6 +82,8 @@ if [ "$1" == 'multi-uninstall' ] || [ "$1" == 'multi-install' ];then
   elif [ "$1" == 'multi-install' ];then
     action=install
   fi
+  
+  echo
   
   app_list="$2" #newline-separated list of apps to install/uninstall
   
@@ -127,6 +131,8 @@ $app"
   
 elif [ "$1" == 'install-if-not-installed' ];then
   
+  echo
+  
   #if not installed
   if [ "$(app_status "$2")" != installed ];then
     #install it
@@ -134,6 +140,7 @@ elif [ "$1" == 'install-if-not-installed' ];then
   fi
   
 elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
+  echo
   #for this operation, a program name must be specified.
   app="$2"
   if [ -z "$app" ];then
@@ -150,13 +157,13 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
   
   #ensure not a disabled app
   if [ "$mode" == install ] && [ "$(app_status "${app}")" == 'disabled' ];then
-    echo -e "\e[93mNot installing the $app app. IT IS DISABLED.\e[39m"
+    warning "Not installing the $app app. IT IS DISABLED."
     exit 0
   fi
   
   #display warning if hardware and os is unsupported
   if [ "$supported" == no ];then
-    echo -e "\e[103m\e[30mWARNING: YOUR SYSTEM IS UNSUPPORTED:\n$(is_supported_system)\e[39m\e[49m"
+    warning "YOUR SYSTEM IS UNSUPPORTED:\n$(is_supported_system)"
     sleep 1
     echo -e "\e[103m\e[30mThe ability to send error reports has been disabled.\e[39m\e[49m"
     sleep 1
@@ -196,23 +203,25 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
   
   chmod u+x "$appscript"
   
-  echo -e "\e[96m${mode^}ing \e[1m${app}\e[0m\e[96m...\e[39m" | tee -a "$logfile"
+  status "${mode^}ing \e[1m${app}\e[0m\e[96m..." | tee -a "$logfile"
+  echo
   cd $HOME
   echo 'corrupted' > "${DIRECTORY}/data/status/${app}"
   nice "$appscript" &> >(tee -a "$logfile")
   if [ $? == 0 ]; then #if app script succeeded
     #change the status from corrupted to 'installed' or 'uninstalled'
     echo "${mode}ed" > "${DIRECTORY}/data/status/${app}"
-    echo -e "\n\e[42m\e[30m${mode^}ed ${app} successfully.\e[39m\e[49m" | tee -a "$logfile"
+    status_green "\n${mode^}ed ${app} successfully." | tee -a "$logfile"
     
     format_log_file "$logfile" #remove escape sequences from logfile
     mv "$logfile" "$(echo "$logfile" | sed 's+-incomplete-+-success-+g')" #
+    echo
     exit 0
   else
-    echo -e "\n\e[91mFailed to ${mode} ${app} with $scriptname script"\!"\e[39m
+    error "\nFailed to ${mode} ${app} with $scriptname script"\!"\e[39m
 \e[40m\e[93m\e[5m▲\e[25m\e[39m \e[49m\e[93mNeed help? Copy the \e[1mENTIRE\e[0m\e[49m\e[93m terminal output or take a screenshot.
 Please ask on Github: \e[94m\e[4mhttps://github.com/Botspot/pi-apps/issues/new/choose\e[24m\e[93m
-Or on Discord: \e[94m\e[4mhttps://discord.gg/RXSTvaUvuu\e[24m\e[39m" | tee -a "$logfile"
+Or on Discord: \e[94m\e[4mhttps://discord.gg/RXSTvaUvuu" | tee -a "$logfile"
     
     format_log_file "$logfile" #remove escape sequences from logfile
     mv "$logfile" "$(echo "$logfile" | sed 's+-incomplete-+-fail-+g')"
@@ -220,12 +229,20 @@ Or on Discord: \e[94m\e[4mhttps://discord.gg/RXSTvaUvuu\e[24m\e[39m" | tee -a "$
   fi
   
 elif [ "$1" == 'update' ];then
+  echo
   #UPDATE
   #for this operation, a program name must be specified.
   app="$2"
   if [ -z "$app" ];then
     error "For this operation, you must specify which app to operate on."
   fi
+  
+  #detect which installation script exists and get the hash for that one
+  scriptname="$(script_name_cpu "$app")"
+  [ $? == 1 ] && exit 1
+  
+  status "Updating \e[1m${app}\e[0m\e[96m..."
+  echo
   
   #HIDDEN FEATURE - if $3 equals nofetch, then don't download github repo. Useful for updating multiple apps at maximum speed
   if [ "$3" == 'nofetch' ] && [ -d "${DIRECTORY}/update" ];then
@@ -235,9 +252,7 @@ elif [ "$1" == 'update' ];then
     git clone --depth=1 "$(cat "${DIRECTORY}/etc/git_url")" || error "failed to clone repository!"
   fi
   
-  #detect which installation script exists and get the hash for that one
-  scriptname="$(script_name_cpu "$app")"
-  [ $? == 1 ] && exit 1
+  echo
   
   newinstallhash="$(sha1sum "${DIRECTORY}/update/pi-apps/apps/${app}/${scriptname}" 2>/dev/null | awk '{print $1}')"
   oldinstallhash="$(sha1sum "${DIRECTORY}/apps/${app}/${scriptname}" 2>/dev/null | awk '{print $1}')"
@@ -246,17 +261,20 @@ elif [ "$1" == 'update' ];then
   #echo -e "newhash: $newhash\noldhash: $oldhash"
   
   if diff -r "${DIRECTORY}/apps/${app}" "${DIRECTORY}/update/pi-apps/apps/${app}" -q >/dev/null;then
-    echo "$app is identical to the online version. Nothing to do!"
+    status_green "$app is identical to the online version. Nothing to do!"
+    echo
     exit 0
   fi
   #else
-  echo "$app is not identical to the online version."
+  status_green "$app is not identical to the online version."
   installback=no
+  
+  echo
   
   #if install script was changed                                                    #if installed already
   if [ "$newinstallhash" != "$oldinstallhash" ] && [ "$(app_status "${app}")" == 'installed' ];then
     installback=yes
-    echo "$app's install script has been updated. Reinstalling $app..."
+    status "$app's install script has been updated. Reinstalling $app..."
     #uninstall it using a recursive script instance
     "${DIRECTORY}/manage" uninstall "$app"
     
@@ -275,13 +293,26 @@ elif [ "$1" == 'update' ];then
   cp -rf "${DIRECTORY}/update/pi-apps/apps/${app}" "${DIRECTORY}/apps/${app}"
   
   if [ "$installback" == 'yes' ];then
-    echo "$app was originally installed before updating. Reinstalling the new version now."
     #install it using a recursive script instance
     "${DIRECTORY}/manage" install "$app"
+    if [ $? == 0 ]; then
+      failed=true
+    else
+      failed=false
+    fi
   fi
-  echo -e "\e[92m${app} was updated successfully.\e[39m"
+  
+  if [ "$failed" == 'true' ]; then
+    error "Failed to update ${app}."
+  else
+    status_green "${app} was updated successfully."
+  fi
+  echo
   
 elif [ "$1" == 'check-all' ];then
+  
+  echo 
+  
   #CHECK-ALL
   #for this operation, a program name cannot be specified.
   
@@ -352,6 +383,9 @@ ${app}"
   
   echo "${updatable}"
 elif [ "$1" == 'update-all' ];then
+
+  echo
+
   #UPDATE-ALL
   #for this operation, a program name cannot be specified.
   IFS=$'\n'
@@ -362,12 +396,12 @@ elif [ "$1" == 'update-all' ];then
   echo "Updatable: ${updatable}EOU"
   for updateapp in $updatable
   do
-    echo "updating $updateapp"
+    status "updating $updateapp"
     #update it using a recursive script instance
     echo "${DIRECTORY}/manage update $updateapp"
     "${DIRECTORY}/manage" update "$updateapp" || exit 1
   done
-  echo -e '\e[92mOperation completed successfully!\e[39m'
+  status_green "Operation completed successfully!"
 else
-  error "Did not understand $1. Allowed values: 'install', 'multi-install', 'install-if-not-installed', 'uninstall', 'multi-uninstall', 'update','update-all', or 'check-all'."
+  error "Invalid argument. Allowed values: 'install', 'multi-install', 'install-if-not-installed', 'uninstall', 'multi-uninstall', 'update','update-all', or 'check-all'."
 fi

--- a/purge-installed
+++ b/purge-installed
@@ -11,6 +11,10 @@ function error {
   exit 1
 }
 
+reduceapt() { #remove unwanted lines from apt output
+  grep -v "apt does not have a stable CLI interface.\|Reading package lists...\|Building dependency tree\|Reading state information...\|Need to get\|After this operation,\|Get:\|Fetched\|Selecting previously unselected package\|Preparing to unpack\|Unpacking \|Setting up \|Processing triggers for "
+}
+
 DIRECTORY="$(readlink -f "$(dirname "$0")")"
 
 echo -e "\e[97m\nRunning purge-installed...\e[39m"
@@ -34,7 +38,7 @@ if dpkg -l pi-apps-$appnamehash &>/dev/null ;then
   #new pkg-install implementation - using dummy debs
   
   echo -e "\e[97m\nRemoving dummy deb for $app...\e[39m"
-  sudo -E apt purge -y pi-apps-$appnamehash --autoremove || error "apt failed to purge dummy deb (pi-apps-$appnamehash)!"
+  sudo -E apt purge -y pi-apps-$appnamehash --autoremove 2>&1 | reduceapt || error "apt failed to purge dummy deb (pi-apps-$appnamehash)!"
   
 elif [ -f "${DIRECTORY}/data/installed-packages/${app}" ];then
   #old pkg-install implementation
@@ -59,6 +63,6 @@ else
   echo "purge-installed: Neither dummy deb nor installed-packages file detected. Nothing to do!"
 fi
 
-
-echo -e "\e[32mAll packages have been purged succesfully.\e[39m"
+echo
+status_green "All packages have been purged succesfully."
 rm -f "${DIRECTORY}/data/installed-packages/${app}"

--- a/updater
+++ b/updater
@@ -19,7 +19,7 @@ get_date() {
 check_update_interval() { #return 0 if update-interval allows update-checking today, exit 1 otherwise
   local lastupdatecheck="$(cat "${DIRECTORY}/data/last-update-check" 2>/dev/null)"
   if [ -z $lastupdatecheck ];then
-    echo "Warning: ${DIRECTORY}/data/last-update-check does not exist!" 1>&2
+    warning "Warning: ${DIRECTORY}/data/last-update-check does not exist!" 1>&2
     lastupdatecheck=0
   fi
   
@@ -44,9 +44,9 @@ check_update_interval() { #return 0 if update-interval allows update-checking to
   elif [ "$updateinterval" == 'Always' ];then
     return 0
   elif [ -z "$updateinterval" ];then
-    echo "Something isn't right. Does '${DIRECTORY}/data/settings/Check for updates' exist?" 1>&2
+    warning "Something isn't right. Does '${DIRECTORY}/data/settings/Check for updates' exist?" 1>&2
   else
-    echo "Warning: Unrecognized update interval!" 1>&2
+    error "Unrecognized update interval!" 1>&2
   fi
   
   return 0
@@ -188,7 +188,7 @@ list_updates_gui() { #input: updatable_apps and updatable_files variables
   #echo "List: ${LIST}EOL"
   
   if [ -z "$LIST" ];then
-    echo -e '\e[92mNothing to update. Nothing to do!\e[39m'
+    status_green "mNothing to update. Nothing to do!"
     exit 0
   fi
   
@@ -217,14 +217,15 @@ update_now_gui() { #input: updatable_files and updatable_apps variables
     mkdir -p "$(dirname "${DIRECTORY}/${file}")"
     
     #copy new version
-    cp -f "${DIRECTORY}/update/pi-apps/${file}" "${DIRECTORY}/${file}" || echo -e "\e[91mFailed to copy ${DIRECTORY}/update/pi-apps/${file}\e[39m!"
+    cp -f "${DIRECTORY}/update/pi-apps/${file}" "${DIRECTORY}/${file}" || error "Failed to copy ${DIRECTORY}/update/pi-apps/${file}!"
     
     #special edge-case: if current file ends in .c, delete the corresponsing executable so that it will be recompiled.
     if [[ "$file" == *.c ]];then
       rm -f "${DIRECTORY}/$(echo "$file" | sed 's/\.c$//g')"
     fi
     
-    echo -e "\e[92m${file} file was copied successfully.\e[39m"
+    echo
+    status_green "${file} file was copied successfully."
   done
   IFS="$PREIFS"
   
@@ -248,7 +249,7 @@ update_now_gui() { #input: updatable_files and updatable_apps variables
   rm -rf "${DIRECTORY}/.git" || sudo rm -rf "${DIRECTORY}/.git" || error "Failed to delete old ${DIRECTORY}/.git folder!"
   cp -a "${DIRECTORY}/update/pi-apps/.git" "${DIRECTORY}" || error "Failed to copy new .git folder!"
   
-  echo -e "\e[92mPi-Apps updates complete.\e[39m"
+  status_green "\nPi-Apps updates complete.\n"
 }
 
 update_now_cli() { #input: updatable_files and updatable_apps variables
@@ -258,14 +259,14 @@ update_now_cli() { #input: updatable_files and updatable_apps variables
     mkdir -p "$(dirname "${DIRECTORY}/${file}")"
     
     #copy new version
-    cp -f "${DIRECTORY}/update/pi-apps/${file}" "${DIRECTORY}/${file}" || echo -e "\e[91mFailed to copy ${DIRECTORY}/update/pi-apps/${file}\e[39m!"
+    cp -f "${DIRECTORY}/update/pi-apps/${file}" "${DIRECTORY}/${file}" || error "Failed to copy ${DIRECTORY}/update/pi-apps/${file}!"
     
     #special edge-case: if current file ends in .c, delete the corresponsing executable so that it will be recompiled.
     if [[ "$file" == *.c ]];then
       rm -f "${DIRECTORY}/$(echo "$file" | sed 's/\.c$//g')"
     fi
     
-    echo -e "\e[92m${file} file was copied successfully.\e[39m"
+    status_green "${file} file was copied successfully."
   done
   
   for app in $updatable_apps ;do
@@ -276,7 +277,7 @@ update_now_cli() { #input: updatable_files and updatable_apps variables
   rm -rf "${DIRECTORY}/.git" || sudo rm -rf "${DIRECTORY}/.git" || error "Failed to delete old ${DIRECTORY}/.git folder!"
   cp -a "${DIRECTORY}/update/pi-apps/.git" "${DIRECTORY}" || error "Failed to copy new .git folder!"
   
-  echo -e "\e[92mPi-Apps updates complete.\e[39m"
+  status_green "\nPi-Apps updates complete."
 }
 
 screen_width="$(xrandr | grep "HDMI-1" | awk '{print $4}' | tr 'x+' ' ' | awk '{print $1}')"
@@ -296,19 +297,19 @@ fi
 
 #runmode values: autostarted, get-status, set-status, gui, gui-yes, cli, cli-yes
 
-echo "Updater mode: $runmode"
+status "\nUpdater mode: $runmode\n"
 if [ "$runmode" == autostarted ];then #if update-interval allows, and one app installed, display notification on boot
   
   #check if update interval allows update-checks, otherwise exit
   check_update_interval
   if [ $? != 0 ];then
-    echo "Won't check for updates today, because of the update interval is set to '$(cat "${DIRECTORY}/data/settings/Check for updates")' in Settings."
+    status "Won't check for updates today, because of the update interval is set to '$(cat "${DIRECTORY}/data/settings/Check for updates")' in Settings."
     exit 0
   fi
   
   #check that at least one app has been installed by the user
   if [ "$(ls "${DIRECTORY}/data/status" | wc -l)" == 0 ];then
-    echo "No apps have been installed yet, so exiting now."
+    status "No apps have been installed yet, so exiting now."
     exit 0
   fi
   
@@ -316,11 +317,11 @@ if [ "$runmode" == autostarted ];then #if update-interval allows, and one app in
   updatable_files="$(get_updatable_files)"
 
   if [ -z "$updatable_files" ] && [ -z "$updatable_apps" ];then
-    echo "Nothing is updatable."
+    status "Nothing is updatable."
     exit 0
   fi
   
-  echo "Displaying notification in lower-right of screen..."
+  status "Displaying notification in lower-right of screen..."
   { #display notification in lower-right
     output="$(yad --form --text='Pi-Apps updates available.' --separator='\n' \
       --on-top --skip-taskbar --undecorated --close-on-unfocus \
@@ -363,7 +364,7 @@ if [ "$runmode" == autostarted ];then #if update-interval allows, and one app in
   
   list_updates_gui
   if [ -z "$updatable_files" ] && [ -z "$updatable_apps" ];then
-    echo "User did not allow anything to be updated."
+    status "User did not allow anything to be updated."
     exit 0
   fi
   
@@ -400,13 +401,16 @@ elif [ "$runmode" == gui ];then #dialog-list of updatable apps, with checkboxes 
   updatable_files="$(get_updatable_files)"
   
   if [ -z "$updatable_files" ] && [ -z "$updatable_apps" ];then
-    echo "Nothing is updatable."
+    status "Nothing is updatable."
     exit 0
   fi
   
+  echo
+  
   list_updates_gui
   if [ -z "$updatable_files" ] && [ -z "$updatable_apps" ];then
-    echo "User did not allow anything to be updated."
+    status "User did not allow anything to be updated."
+    echo
     exit 0
   fi
   
@@ -420,7 +424,7 @@ elif [ "$runmode" == gui-yes ];then #update now without asking for confirmation
   updatable_files="$(get_updatable_files)"
   
   if [ -z "$updatable_files" ] && [ -z "$updatable_apps" ];then
-    echo "Nothing is updatable."
+    status "Nothing is updatable."
     exit 0
   fi
   
@@ -430,50 +434,84 @@ elif [ "$runmode" == cli ];then #return list of updatable apps, and ask the user
   
   updatable_apps="$(get_updatable_apps)"
   updatable_files="$(get_updatable_files)"
+  echo 
   
   if [ -z "$updatable_files" ] && [ -z "$updatable_apps" ];then
-    echo "Nothing is updatable."
+    status "Nothing is updatable."
     exit 0
   fi
   
-  echo "These apps can be updated:"
-  echo -n "$updatable_apps" | sed 's/^/  - /g'
-  echo
+  if [ -z "$updatable_apps" ];then
+    status "No apps is updatable."
+    echo
+  else
+    status "These apps can be updated:"
+    echo
+    echo "$updatable_apps" | sed 's/^/  - /g'
+    echo
+  fi
   
-  echo "These files can be updated:"
-  echo -n "$updatable_files" | sed 's/^/  - /g'
-  echo
+  if [ -z "$updatable_files" ];then
+    status "No files is updatable"
+    echo
+  else
+    status "These files can be updated:"
+    echo
+    echo "$updatable_files" | sed 's/^/  - /g'
+    echo
+  fi
   
-  read -p "Update now? [Y/n] " answer
+  question=$(status 'Update now? [Y/n] ')
+  read -p "$question" answer
   
   if [ "$answer" == n ] || [ "$answer" == N ];then
+    echo
+    echo "Exiting now."
+    echo
     exit 0
   fi
   
+  echo
   update_now_cli
   
 elif [ "$runmode" == cli-yes ];then #update now without asking for confirmation
   
   updatable_apps="$(get_updatable_apps)"
   updatable_files="$(get_updatable_files)"
+  echo 
   
   if [ -z "$updatable_files" ] && [ -z "$updatable_apps" ];then
-    echo "Nothing is updatable."
+    status "Nothing is updatable."
     exit 0
   fi
   
-  echo "These apps can be updated:"
-  echo -n "$updatable_apps" | sed 's/^/  - /g'
+  if [ -z "$updatable_apps" ];then
+    status "No apps is updatable."
+    echo
+  else
+    status "These apps can be updated:"
+    echo
+    echo "$updatable_apps" | sed 's/^/  - /g'
+    echo
+  fi
   
-  echo "These files can be updated:"
-  echo -n "$updatable_files" | sed 's/^/  - /g'
+  if [ -z "$updatable_files" ];then
+    status "No files is updatable"
+    echo
+  else
+    status "These files can be updated:"
+    echo
+    echo "$updatable_files" | sed 's/^/  - /g'
+    echo
+  fi
+  
   echo
-  
   update_now_cli
   
 else
-  error "updater: unknown run mode."
+  error "updater: unknown run mode. Exiting now.\n"
 fi
 
+echo 
 exit 0
 } #prevents errors if script was modified while in use

--- a/updater
+++ b/updater
@@ -19,7 +19,7 @@ get_date() {
 check_update_interval() { #return 0 if update-interval allows update-checking today, exit 1 otherwise
   local lastupdatecheck="$(cat "${DIRECTORY}/data/last-update-check" 2>/dev/null)"
   if [ -z $lastupdatecheck ];then
-    warning "Warning: ${DIRECTORY}/data/last-update-check does not exist!" 1>&2
+    warning "${DIRECTORY}/data/last-update-check does not exist!" 1>&2
     lastupdatecheck=0
   fi
   

--- a/updater
+++ b/updater
@@ -46,7 +46,7 @@ check_update_interval() { #return 0 if update-interval allows update-checking to
   elif [ -z "$updateinterval" ];then
     warning "Something isn't right. Does '${DIRECTORY}/data/settings/Check for updates' exist?" 1>&2
   else
-    error "Unrecognized update interval!" 1>&2
+    echo -e "\e[91mUnrecognized update interval! \e[0m" 1>&2
   fi
   
   return 0
@@ -217,7 +217,7 @@ update_now_gui() { #input: updatable_files and updatable_apps variables
     mkdir -p "$(dirname "${DIRECTORY}/${file}")"
     
     #copy new version
-    cp -f "${DIRECTORY}/update/pi-apps/${file}" "${DIRECTORY}/${file}" || error "Failed to copy ${DIRECTORY}/update/pi-apps/${file}!"
+    cp -f "${DIRECTORY}/update/pi-apps/${file}" "${DIRECTORY}/${file}" || echo -e "\e[91mFailed to copy ${DIRECTORY}/update/pi-apps/${file}! \e[0m"
     
     #special edge-case: if current file ends in .c, delete the corresponsing executable so that it will be recompiled.
     if [[ "$file" == *.c ]];then
@@ -259,7 +259,7 @@ update_now_cli() { #input: updatable_files and updatable_apps variables
     mkdir -p "$(dirname "${DIRECTORY}/${file}")"
     
     #copy new version
-    cp -f "${DIRECTORY}/update/pi-apps/${file}" "${DIRECTORY}/${file}" || error "Failed to copy ${DIRECTORY}/update/pi-apps/${file}!"
+    cp -f "${DIRECTORY}/update/pi-apps/${file}" "${DIRECTORY}/${file}" || echo -e "\e[91mFailed to copy ${DIRECTORY}/update/pi-apps/${file}! \e[0m"
     
     #special edge-case: if current file ends in .c, delete the corresponsing executable so that it will be recompiled.
     if [[ "$file" == *.c ]];then
@@ -461,8 +461,7 @@ elif [ "$runmode" == cli ];then #return list of updatable apps, and ask the user
     echo
   fi
   
-  question=$(status 'Update now? [Y/n] ')
-  read -p "$question" answer
+  read -p "$(status 'Update now? [Y/n] ')" answer
   
   if [ "$answer" == n ] || [ "$answer" == N ];then
     echo


### PR DESCRIPTION
Add some `echo` to scripts and replace most `echo` with new api message functions: `status`, `status_green` and `warning`.

Fix some minor bugs.


- Use `\e[0m` as closing for `echo -e` 
- Add few `echo` to create newlines to make output neater
- Replace most `echo` with new api message functions
- Check app name before update in `manage`
- Show error messages if update failed in `manage` 
- Add `reduceapt` in `purge-installed`
- Show `No apps/files is updatable` if there isn't any app/files to update in `updater`