### PR TITLE
Remove `terminal-run` in Zoom script

### DIFF
--- a/apps/Zoom/install-32
+++ b/apps/Zoom/install-32
@@ -63,7 +63,7 @@ chmod +x "${HOME}/zoom/runzoom.sh"
 echo "Creating a Zoom button in the Main Menu..."
 echo "[Desktop Entry]
 Name=Zoom
-Exec=${DIRECTORY}/etc/terminal-run "\""$HOME/zoom/runzoom.sh %u"\"" 'Close this window to exit Zoom'
+Exec=$HOME/zoom/runzoom.sh %u
 Icon=$(dirname "$0")/icon-64.png
 Path=${HOME}/zoom/
 Type=Application

--- a/apps/Zoom/install-32
+++ b/apps/Zoom/install-32
@@ -58,7 +58,7 @@ fi
 cd ${HOME}/zoom/
 echo -e "\e[102m\e[30mLaunching Zoom.\e[0m"
 box86 zoom "$1"' > "${HOME}/zoom/runzoom.sh"
-chmod +x "${HOME}/zoom/runzoom.sh"
+chmod +x "${HOME}/zoom/runzoom.sh" || sudo chmod +x "${HOME}/zoom/runzoom.sh"
 
 echo "Creating a Zoom button in the Main Menu..."
 echo "[Desktop Entry]

--- a/apps/Zoom/install-64
+++ b/apps/Zoom/install-64
@@ -61,7 +61,7 @@ fi
 cd ${HOME}/zoom/
 echo -e "\e[102m\e[30mLaunching Zoom.\e[0m"
 box64 zoom' > "${HOME}/zoom/runzoom.sh"
-chmod +x "${HOME}/zoom/runzoom.sh"
+chmod +x "${HOME}/zoom/runzoom.sh" || sudo chmod +x "${HOME}/zoom/runzoom.sh"
 
 echo "Creating a Zoom button in the Main Menu..."
 echo "[Desktop Entry]

--- a/apps/Zoom/install-64
+++ b/apps/Zoom/install-64
@@ -66,7 +66,7 @@ chmod +x "${HOME}/zoom/runzoom.sh"
 echo "Creating a Zoom button in the Main Menu..."
 echo "[Desktop Entry]
 Name=Zoom
-Exec=${DIRECTORY}/etc/terminal-run "\""$HOME/zoom/runzoom.sh %u"\"" 'Close this window to exit Zoom'
+Exec=$HOME/zoom/runzoom.sh %u
 Icon=$(dirname "$0")/icon-64.png
 Path=${HOME}/zoom/
 Type=Application


### PR DESCRIPTION
Since there is `chmod +x "${HOME}/zoom/runzoom.sh"` in the installation script, Zoom can run without `terminal-run` script.