### PR TITLE
Fix a minor syntax error in genapplist-yad.c

### DIFF
--- a/etc/genapplist-yad.c
+++ b/etc/genapplist-yad.c
@@ -96,7 +96,6 @@ void get_app_status_with_none(char *directory, const char *app, char *status, si
 		snprintf(status, size, "%s", st);
 	} else {
 			snprintf(status, size, "none");
-		}
 	}
 }
 


### PR DESCRIPTION
Fix a syntax error causing 
```
/home/pi/pi-apps/etc/genapplist-yad.c:101:1: error: expected identifier or ‘(’ before ‘}’ token
 }
 ^
./pi-apps/preload: line 42: /home/pi/pi-apps/etc/genapplist-yad: No such file or directory
The genapplist-yad program failed to compile.
```
while running `preload` standalone
As logs can be seen only if script is run as standalone