### PR TITLE
Remove `apt` unwanted lines in `box86` uninstall script

### DIFF
--- a/apps/Box86/uninstall
+++ b/apps/Box86/uninstall
@@ -41,4 +41,5 @@ else
 fi
 
 echo "running 'sudo apt update'..."
-sudo apt update
+sudo apt update 2>&1 | grep -v "apt does not have a stable CLI interface.\|Reading package lists...\|Building dependency tree\|Reading state information...\|Need to get\|After this operation,\|Get:\|Fetched\|Selecting previously unselected package\|Preparing to unpack\|Unpacking \|Setting up \|Processing triggers for "
+

--- a/apps/Box86/uninstall
+++ b/apps/Box86/uninstall
@@ -39,7 +39,3 @@ elif [ "$arch" == 32 ]; then
 else
   error "Can't detect OS architecture! something is very wrong!"
 fi
-
-echo "running 'sudo apt update'..."
-sudo apt update 2>&1 | grep -v "apt does not have a stable CLI interface.\|Reading package lists...\|Building dependency tree\|Reading state information...\|Need to get\|After this operation,\|Get:\|Fetched\|Selecting previously unselected package\|Preparing to unpack\|Unpacking \|Setting up \|Processing triggers for "
-


### PR DESCRIPTION
Just remove `apt` unwanted lines after last line `sudo apt update`.
