### PR TITLE
Use `rm -f` and suppress output in tldr uninstall script

### DIFF
--- a/apps/tldr/uninstall
+++ b/apps/tldr/uninstall
@@ -7,5 +7,5 @@ function error {
   exit 1
 }
 
-tldr --clear-cache
-sudo rm /usr/bin/tldr
+tldr --clear-cache &>/dev/null
+rm -f /usr/bin/tldr || sudo rm -f /usr/bin/tldr &>/dev/null


### PR DESCRIPTION
Prevent 
```
/home/pi/pi-apps/apps/tldr/uninstall: line 10: tldr: command not found  
rm: cannot remove '/usr/bin/tldr': No such file or directory
```

from causing the uninstallation fail.