### PR TITLE
Fix typo in MC Java install-64

### DIFF
--- a/apps/Minecraft Java/install-64
+++ b/apps/Minecraft Java/install-64
@@ -8,7 +8,7 @@ function error {
 }
 
 echo "Installing dependencies"
-${DIRECTORY}/pkg-install" "kmod zip unzip" "$(dirname "$0")" || exit 1
+"${DIRECTORY}/pkg-install" "kmod zip unzip" "$(dirname "$0")" || exit 1
 
 echo "Creating directories"
 mkdir -p ~/.minecraft ~/lwjgl3arm64 ~/lwjgl2arm64 ~/lunarassets


### PR DESCRIPTION
Fix `/home/{user}/pi-apps/apps/Minecraft Java/install-64: line 11: /home/jacob/pi-apps/pkg-install kmod: No such file or directory`
`/home/{user}/pi-apps/apps/Minecraft Java/install-64: line 51: syntax error near unexpected token '('`
`/home/{user}/pi-apps/apps/Minecraft Java/install-64: line 51: 'Name=Minecraft Launcher (Lunar)'`