### PR TITLE
Improve `aria2c` output

### DIFF
--- a/api
+++ b/api
@@ -1399,7 +1399,7 @@ wget() { #Intercept all wget commands. When possible, uses aria2c.
   echo "$@" | grep -qe "-q[[:space:]]" && quiet=1
   
   if [ "$quiet" == 0 ];then
-    status -n "Downloading $(basename "$url")... "
+    status "Downloading $(basename "$url")... "
   fi
   
   #now, perform the download using the chosen method


### PR DESCRIPTION
Made some enhancement to `aria2c` output.

- Display downloading message instead of hanging the screen while downloading file 
- Check for `-q` and `-qo-` flags more accurately
- Use `--quiet` flag to suppress output
- Directly `exit 1` if download failed (this may break some scripts)