### PR TITLE
Remove `yad` as it was installed when installation of pi-apps

### DIFF
--- a/apps/Pi Power Tools/install
+++ b/apps/Pi Power Tools/install
@@ -8,6 +8,6 @@ function error {
 }
 
 # Get dependencies
-"${DIRECTORY}/pkg-install" "yad systemd-container xserver-xephyr expect" "$(dirname "$0")" || exit 1
+"${DIRECTORY}/pkg-install" "systemd-container xserver-xephyr expect" "$(dirname "$0")" || exit 1
 
 wget -O - https://raw.githubusercontent.com/Botspot/Pi-Power-Tools/master/update | bash


### PR DESCRIPTION
Avoid accidentally uninstall `yad`.