### PR TITLE
Fix `git_clone` not working

### DIFF
--- a/api
+++ b/api
@@ -1333,7 +1333,7 @@ git_clone() { #silently clone a git repository but display the output if an erro
   # $1 is repo
   local IFS=' '
   for arg in "$@"; do
-    if [[ "$arg" == *:// ]];then
+    if [[ "$arg" == *'://'* ]];then
       url="$arg"
     fi
   done


### PR DESCRIPTION
Correctly check URL using `*'://'*` instead of `*://`.