### PR TITLE
change wget function to custom_get

### DIFF
--- a/api
+++ b/api
@@ -1366,7 +1366,7 @@ git_clone() { #silently clone a git repository but display the output if an erro
   status 'Done'
 }
 
-wget() { #Intercept all wget commands. When possible, uses aria2c.
+get_custom() { #Intercept all wget commands. When possible, uses aria2c.
   local file=''
   local url=''
   local use=aria2c


### PR DESCRIPTION
overwriting a builtin function name is very dangerous since the get_custom function does NOT adhere to wget spec. Script writers should have to actively changes to this function if they want its features and not be forced to use it

explained here:
https://discord.com/channels/770629697909424159/770629697909424162/898429620662177812
https://discord.com/channels/770629697909424159/770629697909424162/898570566141898862