### PR TITLE
checkout newer MultiMC5 commit

### DIFF
--- a/apps/Minecraft Java MultiMC5/install
+++ b/apps/Minecraft Java MultiMC5/install
@@ -158,7 +158,7 @@ cd src
 git remote set-url origin https://github.com/MultiMC/Launcher.git
 git checkout --recurse-submodules develop || error "Could not checkout develop branch"
 git pull --recurse-submodules || error "Could Not Pull Latest MultiMC Source Code, verify your ~/MultiMC/src directory hasn't been modified. You can detete the  ~/MultiMC/src folder to attempt to fix this error."
-git checkout --recurse-submodules a8458e36ff84c229f68374dfa5319a147b6bce13 || error "Could Not Checkout MultiMC Source Code commit, verify your ~/MultiMC/src directory hasn't been modified. You can detete the  ~/MultiMC/src folder to attempt to fix this error."
+git checkout --recurse-submodules 6f6c9c6f6848f4167410eedc65e309d0231cf37d || error "Could Not Checkout MultiMC Source Code commit, verify your ~/MultiMC/src directory hasn't been modified. You can detete the  ~/MultiMC/src folder to attempt to fix this error."
 
 # add secrets files
 mkdir -p secrets


### PR DESCRIPTION
fixes liteloader modloading (an alternative to forge for 1.12 and older) and translations that were broken with the initial debrand merge.

I felt like these fixes are important enough to update. Since the source remains on the users install, the update took less than 2 minutes on my machine to compile and install.