### PR TITLE
add software-properties-common to dependencies for multimc5

### DIFF
--- a/apps/Minecraft Java MultiMC5/install
+++ b/apps/Minecraft Java MultiMC5/install
@@ -119,6 +119,8 @@ case "$__os_id" in
                 if [[ $ppa_added -eq "1" ]]; then
                     status "Skipping OpenJDK PPA, already added"
                 else
+                    install_packages software-properties-common || error "Failed to install dependencies"
+                    hash -r
                     status "Adding OpenJDK PPA, needed for Minecraft 1.17+"
                     sudo add-apt-repository ppa:openjdk-r/ppa -y
                     sudo apt update


### PR DESCRIPTION
some users were missing the add-apt-repository command on ubuntu. apparently this is not installed by default in all distros so add it as a dependency here