### PR TITLE
BUGFIX: doom3, Chiaki and Cool Retro Term install for bullseye and ubuntu 21.04+

### DIFF
--- a/apps/Chiaki/install
+++ b/apps/Chiaki/install
@@ -8,7 +8,7 @@ function error {
 }
 
 # install dependencies
-"${DIRECTORY}/pkg-install" "cmake python3-protobuf protobuf-compiler libavcodec-dev libopus-dev libsdl2-dev libssl-dev qt5-default qtmultimedia5-dev libqt5svg5-dev libqt5multimedia5-plugins libqt5opengl5-dev" "$(dirname "$0")" || exit 1
+install_packages cmake python3-protobuf protobuf-compiler libavcodec-dev libopus-dev libsdl2-dev libssl-dev qtbase5-dev qtchooser qtmultimedia5-dev libqt5svg5-dev libqt5multimedia5-plugins libqt5opengl5-dev || error "Failed to install dependencies"
 
 # install Chiaki
 rm -rf ~/Chiaki || error "Failed to first remove $HOME/Chiaki folder!"

--- a/apps/Chiaki/uninstall
+++ b/apps/Chiaki/uninstall
@@ -8,7 +8,7 @@ function error {
 }
 
 # remove dependencies
-"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
+purge_packages || error "Dependencies failed to uninstall"
 
 # remove Chiaki folder and desktop entry
 rm -rf $HOME/Chiaki || error "failed to delete Chiaki folder!"

--- a/apps/Cool Retro Term/install
+++ b/apps/Cool Retro Term/install
@@ -7,7 +7,7 @@ function error {
   exit 1
 }
 # Get dependencies
-"${DIRECTORY}/pkg-install" "build-essential qmlscene qt5-qmake qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtgraphicaleffects qml-module-qtquick-dialogs qml-module-qtquick-localstorage qml-module-qtquick-window2 qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel" "$(dirname "$0")" || exit 1
+install_packages build-essential qmlscene qt5-qmake qtbase5-dev qtchooser qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtgraphicaleffects qml-module-qtquick-dialogs qml-module-qtquick-localstorage qml-module-qtquick-window2 qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel || error "Failed to install dependencies"
 
 # Remove cool-retro-term folder first
 rm -rf cool-retro-term || sudo rm -rf cool-retro-term 

--- a/apps/Cool Retro Term/uninstall
+++ b/apps/Cool Retro Term/uninstall
@@ -11,6 +11,6 @@ rm -rf ~/.cache/cool-retro-term
 rm -rf ~/cool-retro-term
 rm -f ~/.local/share/applications/crt.desktop
 
-"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
+purge_packages || error "Dependencies failed to uninstall"
 
 rm -rf ~/.local/share/cool-retro-term ~/cool-retro-term

--- a/apps/Doom 3/install-32
+++ b/apps/Doom 3/install-32
@@ -10,10 +10,10 @@ function error {
 rm -rf ~/RPIDoom3Installer || sudo rm -rf ~/RPIDoom3Installer || error "Failed to first remove ~/RPIDoom3Installer folder!"
 
 # Get dependencies
-"${DIRECTORY}/pkg-install" "libfontconfig-dev qt5-default automake mercurial libtool libfreeimage-dev \
+install_packages libfontconfig-dev qtbase5-dev qtchooser automake mercurial libtool libfreeimage-dev \
 libopenal-dev libpango1.0-dev libsndfile-dev libudev-dev libtiff5-dev libwebp-dev libasound2-dev \
 libaudio-dev libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxss-dev libesd0-dev \
-freeglut3-dev libmodplug-dev libsmpeg-dev libjpeg-dev libogg-dev libvorbis-dev libvorbisfile3 libcurl4 cmake aria2 lolcat figlet" "$(dirname "$0")" || exit 1
+freeglut3-dev libmodplug-dev libsmpeg-dev libjpeg-dev libogg-dev libvorbis-dev libvorbisfile3 libcurl4 cmake aria2 lolcat figlet || error "Failed to install dependencies"
 
 git clone https://github.com/techcoder20/RPIDoom3Installer || error 'Failed to clone RPIDoom3Installer repository!'
 cd ~/RPIDoom3Installer || error "Failed to change directory "

--- a/apps/Doom 3/uninstall
+++ b/apps/Doom 3/uninstall
@@ -8,7 +8,7 @@ function error {
 }
 
 #if your app installs any packages, keep this command here so those packages will be removed.
-"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
+purge_packages || error "Dependencies failed to uninstall"
 
 if [ -d ~/RPIDoom3Installer ];then
   cd ~/RPIDoom3Installer || "Failed to Change directory"


### PR DESCRIPTION
also transition to install_packages and purge_packages while we are at it (to avoid unnecessary double update)

qt5-default no longer exists in these new debian based releases (so install the dependencies instead, it was just a meta package basically)

should fix: https://discord.com/channels/770629697909424159/874656141475463229/903012266708963411 https://discord.com/channels/770629697909424159/874656141475463229/903051515210661920
and many other instances of this error in the #error-logs