### PR TITLE
BUGFIX: add python3(or 2)-dev package whenever pip is installed

### DIFF
--- a/apps/AndroidBuddy/install
+++ b/apps/AndroidBuddy/install
@@ -7,7 +7,7 @@ function error {
   exit 1
 }
 
-"${DIRECTORY}/pkg-install" "adb ffmpeg libsdl2-2.0-0 python3-pip python3-tk gcc git pkg-config meson ninja-build libavcodec-dev libavformat-dev libavutil-dev libsdl2-dev" "$(dirname "$0")" || exit 1
+install_packages adb ffmpeg libsdl2-2.0-0 python3-pip python3-dev python3-tk gcc git pkg-config meson ninja-build libavcodec-dev libavformat-dev libavutil-dev libsdl2-dev || error "Failed to install dependencies"
 
 if [ -e ~/scrcpy ] && [ -e /usr/bin/adb];then
   #SCRCPY

--- a/apps/AndroidBuddy/uninstall
+++ b/apps/AndroidBuddy/uninstall
@@ -7,7 +7,7 @@ function error {
   exit 1
 }
 
-"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
+purge_packages || error "Dependencies failed to uninstall"
 
 rm -rf ~/droidbuddy ~/scrcpy ~/.local/share/applications/scrcpy.desktop ~/.local/share/applications/androidbuddy.desktop 2>/dev/null
 sudo rm -rf /usr/local/share/scrcpy 2>/dev/null

--- a/apps/Email Checker/install
+++ b/apps/Email Checker/install
@@ -13,7 +13,7 @@ function error {
 #example below:
 
 # Get dependencies
-"${DIRECTORY}/pkg-install" "zenity python3-pip yad" "$(dirname "$0")" || exit 1
+install_packages zenity python3-pip python3-dev yad || error "Failed to install dependencies"
 sudo pip3 install imapclient || error "Failed to install imapclient!"
 
 output="$(yad --form --center --width=400 --separator='\n' \

--- a/apps/Email Checker/uninstall
+++ b/apps/Email Checker/uninstall
@@ -15,4 +15,4 @@ fi
 
 rm -f ~/.config/autostart/checkmail.desktop
 
-"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
+purge_packages || error "Dependencies failed to uninstall"

--- a/apps/Minecraft Pi (Modded)/install
+++ b/apps/Minecraft Pi (Modded)/install
@@ -33,5 +33,5 @@ do
   esac
 done
 
-"${DIRECTORY}/pkg-install" "$MCPIL python3-pip" "$(dirname "$0")" || error "Failed to install ${MCPIL} and python3-pip packages!"
+install_packages $MCPIL python3-pip python3-dev || error "Failed to install dependencies"
 pip3 install mcpi || error "The pip3 command failed to install mcpi!"

--- a/apps/Minecraft Pi (Modded)/uninstall
+++ b/apps/Minecraft Pi (Modded)/uninstall
@@ -7,6 +7,6 @@ function error {
   exit 1
 }
 
-"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
+purge_packages || error "Dependencies failed to uninstall"
 
 sudo rm -f /etc/apt/{sources.list,trusted.gpg}.d/mcpi-revival.{list,gpg}

--- a/apps/Pi-Apps Terminal Plugin (python)/install-32
+++ b/apps/Pi-Apps Terminal Plugin (python)/install-32
@@ -8,7 +8,7 @@ function error {
 }
 
 # Get dependencies
-"${DIRECTORY}/pkg-install" "python3-pip" "$(dirname "$0")" || exit 1
+install_packages python3-pip python3-dev || error "Failed to install dependencies"
 
 #Installing dependencies for search argument
 pip3 install python-Levenshtein fuzzywuzzy || error "pip3 failed to python-Levenshtein and fuzzywuzzy"

--- a/apps/Powerline-Shell/install
+++ b/apps/Powerline-Shell/install
@@ -8,7 +8,7 @@ function error {
 }
 
 # Get dependencies
-"${DIRECTORY}/pkg-install" "python3 python3-pip fonts-powerline fonts-fantasque-sans" "$(dirname "$0")" || exit 1
+install_packages python3 python3-pip python3-dev fonts-powerline fonts-fantasque-sans || error "Failed to install dependencies"
 
 wget -qO- https://raw.githubusercontent.com/techcoder20/RPI-PowerlineShell-Installer/main/install.sh | bash || error "install.sh failed!"
 

--- a/apps/Powerline-Shell/uninstall
+++ b/apps/Powerline-Shell/uninstall
@@ -8,6 +8,6 @@ function error {
 }
 
 #if your app installs any packages, keep this command here so those packages will be removed.
-"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 1
+purge_packages || error "Dependencies failed to uninstall"
 
 wget -qO- https://raw.githubusercontent.com/techcoder20/RPI-PowerlineShell-Installer/main/uninstall.sh | bash || error "uninstall.sh failed!"

--- a/apps/Pycharm CE/install
+++ b/apps/Pycharm CE/install
@@ -5,7 +5,7 @@ downloadlink=https://download.jetbrains.com/python/pycharm-community-2021.2.3.ta
 name=pycharm-community
 
 # Get dependencies
-install_packages libc6-dev python3-pip openjdk-11-jdk gcc clang || error "Failed to install dependencies"
+install_packages python3-pip python3-dev openjdk-11-jdk build-essential clang || error "Failed to install dependencies"
 
 rm -f "$(pwd)/${name}.tar.gz"
 wget $downloadlink -O "$(pwd)/${name}.tar.gz" || error "Failed to download $(basename "$downloadlink")"

--- a/apps/Quartz/install-64
+++ b/apps/Quartz/install-64
@@ -7,7 +7,7 @@ function error {
   exit 1
 }
 
-"${DIRECTORY}/pkg-install" "python3 python3-pyqt5 python3-pyqt5.qtwebkit python3-pip gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-alsa gstreamer1.0-libav" "$(dirname "$0")" || error "Failed to install dependencies!"
+install_packages python3 python3-pyqt5 python3-pyqt5.qtwebkit python3-pip python3-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-alsa gstreamer1.0-libav || error "Failed to install dependencies"
 
 cd $HOME
 rm -rf quartz-browser-qt5 || sudo rm -rf quartz-browser-qt5 

--- a/apps/Sysmon/install
+++ b/apps/Sysmon/install
@@ -8,7 +8,7 @@ function error {
 }
 
 # Get dependencies
-"${DIRECTORY}/pkg-install" "python3 python3-pip" "$(dirname "$0")" || exit 1
+install_packages python3 python3-pip python3-dev || error "Failed to install dependencies"
 
 cd /opt
 rm -rf ./sysmon || sudo rm -rf ./sysmon || error "Failed to first remove $(pwd)/sysmon folder!"

--- a/apps/TBOPlayer/install
+++ b/apps/TBOPlayer/install
@@ -8,7 +8,7 @@ function error {
 }
 
 # Get dependencies
-"${DIRECTORY}/pkg-install" "python-pip python-gobject-2 python-dbus python-tk python-gtk2 python-requests tkdnd" "$(dirname "$0")" || exit 1
+install_packages python-pip python-dev python-gobject-2 python-dbus python-tk python-gtk2 python-requests tkdnd || error "Failed to install dependencies"
 
 cd ~ && wget https://github.com/KenT2/tboplayer/tarball/master -O - | tar xz || error "Failed to download!"
 cd KenT2-tboplayer-* && chmod +x setup.sh && ./setup.sh || error "failed to run setup.sh!"

--- a/apps/YouTubuddy/install
+++ b/apps/YouTubuddy/install
@@ -7,7 +7,7 @@ function error {
   exit 1
 }
 
-"${DIRECTORY}/pkg-install" "vlc yad imagemagick jq python python3-pip" "$(dirname "$0")" || error "Failed to install dependencies"
+install_packages vlc yad imagemagick jq python python3-pip python3-dev || error "Failed to install dependencies"
 
 rm -rf ~/youtubuddy
 git clone https://github.com/Botspot/youtubuddy || error 'Failed to clone youtubuddy repository!'


### PR DESCRIPTION
many of these scripts have been seen to fail when the python3-dev packages is missing (resulting in fatal error: Python.h: No such file or directory compilation errors when pip has to compile a package from source)

also update packages to use install_packages and purge_packages (where appropriate)