### PR TITLE
install qt5-default if its available in apt repos

### DIFF
--- a/apps/Chiaki/install
+++ b/apps/Chiaki/install
@@ -10,6 +10,11 @@ function error {
 # install dependencies
 install_packages cmake python3-protobuf protobuf-compiler libavcodec-dev libopus-dev libsdl2-dev libssl-dev qtbase5-dev qtchooser qtmultimedia5-dev libqt5svg5-dev libqt5multimedia5-plugins libqt5opengl5-dev || error "Failed to install dependencies"
 
+# install qt5-default if its availabe in apt (necessary on debian/ubuntu versions prior to bullseye/hirsute)
+package_available qt5-default
+if [[ $? == "0" ]]; then
+  install_packages qt5-default || error "Failed to install dependencies"
+fi
 # install Chiaki
 rm -rf ~/Chiaki || error "Failed to first remove $HOME/Chiaki folder!"
 git clone --single-branch --branch rpi01 https://github.com/Fredrum/chiaki.git Chiaki || error "failed to clone the Chiaki repository!"

--- a/apps/Cool Retro Term/install
+++ b/apps/Cool Retro Term/install
@@ -9,6 +9,11 @@ function error {
 # Get dependencies
 install_packages build-essential qmlscene qt5-qmake qtbase5-dev qtchooser qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtgraphicaleffects qml-module-qtquick-dialogs qml-module-qtquick-localstorage qml-module-qtquick-window2 qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel || error "Failed to install dependencies"
 
+# install qt5-default if its availabe in apt (necessary on debian/ubuntu versions prior to bullseye/hirsute)
+package_available qt5-default
+if [[ $? == "0" ]]; then
+  install_packages qt5-default || error "Failed to install dependencies"
+fi
 # Remove cool-retro-term folder first
 rm -rf cool-retro-term || sudo rm -rf cool-retro-term 
 

--- a/apps/Doom 3/install-32
+++ b/apps/Doom 3/install-32
@@ -15,6 +15,11 @@ libopenal-dev libpango1.0-dev libsndfile-dev libudev-dev libtiff5-dev libwebp-de
 libaudio-dev libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxss-dev libesd0-dev \
 freeglut3-dev libmodplug-dev libsmpeg-dev libjpeg-dev libogg-dev libvorbis-dev libvorbisfile3 libcurl4 cmake aria2 lolcat figlet || error "Failed to install dependencies"
 
+# install qt5-default if its availabe in apt (necessary on debian/ubuntu versions prior to bullseye/hirsute)
+package_available qt5-default
+if [[ $? == "0" ]]; then
+  install_packages qt5-default || error "Failed to install dependencies"
+fi
 git clone https://github.com/techcoder20/RPIDoom3Installer || error 'Failed to clone RPIDoom3Installer repository!'
 cd ~/RPIDoom3Installer || error "Failed to change directory "
 


### PR DESCRIPTION
necessary on debian/ubuntu versions prior to bullseye/hirsute. Previously removed by a prior PR.

Basically this just checks if its in the repo, then install it, if its not, then don't. So dependencies stay clean for newer debian/ubuntu versions and old debian/ubuntu versions are still supported.

@Botspot necessary fix. prior PR merge caused errors for buster users https://discord.com/channels/770629697909424159/874656141475463229/903762557876174909