### PR TITLE
Fix bugs in update, remove verbose flag and check file exists before `cat` in Pycharm install script

### DIFF
--- a/api
+++ b/api
@@ -1625,6 +1625,8 @@ unzip() { #say what is being extracted
 }
 #end of command interceptors
 
+trap "exit 1" INT
+
 cd $HOME
 
 add_english

--- a/api
+++ b/api
@@ -1387,6 +1387,9 @@ is_supported_system() { #return 0 if system is supported, otherwise return 1
   elif cat /proc/version | grep -q Android ;then
     echo "Pi-Apps is not supported on Android. Some apps will work, but others won't."
     return 1
+  elif cat /proc/version | grep -q Microsoft || cat /proc/sys/kernel/osrelease | grep -q WSL || [[ -f "/run/WSL" ]] || [[ -f "/etc/wsl.conf" ]] || [ -n "$WSL_DISTRO_NAME" ]; then
+    echo "Pi-Apps is not supported on WSL."
+    return 1
   elif echo "$PRETTY_NAME" | grep -qi 'stretch\|wheezy\|jessie';then
     echo "Pi-Apps is not supported on your outdated operating system. Expect many apps to fail. Consider upgrading your operating system."
     return 1

--- a/apps/Pycharm CE/install
+++ b/apps/Pycharm CE/install
@@ -36,7 +36,7 @@ cd fsnotifier-pycharm-rpi
 bash $HOME/fsnotifier-pycharm-rpi/make.sh || error "Failed to compile file watcher."
 mkdir -p $HOME/.config/JetBrains/PyCharmCE2021.2/options
 mv -f $HOME/fsnotifier-pycharm-rpi/fsnotifier $HOME/.config/JetBrains/PyCharmCE2021.2/ || error "Failed to move fsnotifier binary to $HOME/.config/JetBrains/PyCharmCE2021.2/."
-echo "$(cat $HOME/.config/JetBrains/PyCharmCE2021.2/idea.properties | grep -v idea.filewatcher.executable.path)" > $HOME/.config/JetBrains/PyCharmCE2021.2/idea.properties
+[ -a $HOME/.config/JetBrains/PyCharmCE2021.2/idea.properties ] && echo "$(cat $HOME/.config/JetBrains/PyCharmCE2021.2/idea.properties | grep -v idea.filewatcher.executable.path)" > $HOME/.config/JetBrains/PyCharmCE2021.2/idea.properties
 echo "idea.filewatcher.executable.path = $HOME/.config/JetBrains/PyCharmCE2021.2/fsnotifier" >> $HOME/.config/JetBrains/PyCharmCE2021.2/idea.properties || error "Failed to add file watcher executable path to $HOME/.config/JetBrains/PyCharmCE2021.2/idea.properties."
 
 status "Remove bundled JRE version message ..."

--- a/apps/Pycharm CE/install
+++ b/apps/Pycharm CE/install
@@ -13,7 +13,7 @@ wget $downloadlink -O "$(pwd)/${name}.tar.gz" || error "Failed to download $(bas
 status "Extracting $(basename $downloadlink) to /opt"
 sudo rm -rf /opt/$name
 sudo mkdir -p /opt/$name
-sudo tar xvzf "$(pwd)/${name}.tar.gz" -C /opt/$name || error "Failed to extract $name.tar.gz"
+sudo tar xzf "$(pwd)/${name}.tar.gz" -C /opt/$name || error "Failed to extract $name.tar.gz"
 rm -f "$(pwd)/${name}.tar.gz"
 sudo mv /opt/$name/*/* /opt/$name/
 

--- a/etc/terminal-run
+++ b/etc/terminal-run
@@ -11,7 +11,6 @@ title="$2"
 #add a line to the terminal's command-to-run that saves the terminal's PID to a known filename
 temp_pid_file="$(mktemp -u)"
 commands="echo "\$""\$" > $temp_pid_file
-trap exit INT
 $commands"
 
 #reset the GTK theme so terminals follow the system GTK theme

--- a/manage
+++ b/manage
@@ -275,8 +275,10 @@ Or on Discord: \e[94m\e[4mhttps://discord.gg/RXSTvaUvuu\e[0m" | tee -a "$logfile
     
     mv "$logfile" "$(echo "$logfile" | sed 's+-incomplete-+-fail-+g')"
   fi
+  
+ 
   #if the app is a package, set its status to whatever dpkg thinks it is
-  elif [ "$(app_type "$app")" == package ];then
+  if [ "$(app_type "$app")" == package ];then
     refresh_pkgapp_status "$app"
   fi
   

--- a/updater
+++ b/updater
@@ -458,7 +458,7 @@ elif [ "$runmode" == cli ];then #return list of updatable apps, and ask the user
     echo
   fi
   
-  read -p "$(status 'Update now? [Y/n] ')" answer
+  read -p "$(status -n 'Update now? [Y/n] ')" answer
   
   if [ "$answer" == n ] || [ "$answer" == N ];then
     echo


### PR DESCRIPTION
- Separate `[ "$(app_type "$app")" == package ]` to a new `if` statement.
- Add `-n` flag in `Update now?` prompt.
- Remove verbose flag in Pycharm install script to fix `/usr/bin/grep: Argument list too long` if installation failed.
- Check if file exists before `cat idea.properties` in Pycharm install script.
- Move `trap exit INT` to api.
- Check for WSL in `is_supported_system`.