### PR TITLE
zoom: remove cmake dependency

### DIFF
--- a/apps/Zoom/install-32
+++ b/apps/Zoom/install-32
@@ -20,9 +20,9 @@ fi
 # Get dependencies
 DISTRO=$(lsb_release -is)
 if [[ "${DISTRO}" == "Debian" || "${DISTRO}" == "Raspbian" ]]; then
-  "${DIRECTORY}/pkg-install" "cmake libxcb-xtest0 libxcb-xfixes0 libturbojpeg0 pulseaudio-utils pulseaudio" "$(dirname "$0")" || exit 1
+  "${DIRECTORY}/pkg-install" "libxcb-xtest0 libxcb-xfixes0 libturbojpeg0 pulseaudio-utils pulseaudio" "$(dirname "$0")" || exit 1
 elif [[ "${DISTRO}" == "Ubuntu" ]]; then
-  "${DIRECTORY}/pkg-install" "cmake libxcb-xtest0 libxcb-xfixes0 libturbojpeg pulseaudio-utils pulseaudio" "$(dirname "$0")" || exit 1
+  "${DIRECTORY}/pkg-install" "libxcb-xtest0 libxcb-xfixes0 libturbojpeg pulseaudio-utils pulseaudio" "$(dirname "$0")" || exit 1
 else 
 	error "This script can't run on your OS! It HAS to be Debian and derivatives like RPiOS or Ubuntu"
 fi

--- a/apps/Zoom/install-64
+++ b/apps/Zoom/install-64
@@ -18,7 +18,7 @@ if ! command -v box64 >/dev/null;then
 fi
 
 # Get dependencies
-"${DIRECTORY}/pkg-install" "cmake libxcb-xtest0 libxcb-xfixes0 libturbojpeg0 | libturbojpeg pulseaudio-utils pulseaudio" "$(dirname "$0")" || exit 1
+"${DIRECTORY}/pkg-install" "libxcb-xtest0 libxcb-xfixes0 libturbojpeg0 | libturbojpeg pulseaudio-utils pulseaudio" "$(dirname "$0")" || exit 1
 
 #refresh list of libraries
 sudo ldconfig


### PR DESCRIPTION
box86/64 isn't being compiled anymore due to apt repos being used, so cmake isn't necessary