### PR TITLE
make changes to wording to comply with upstream desires

### DIFF
--- a/apps/Minecraft Java MultiMC5/description
+++ b/apps/Minecraft Java MultiMC5/description
@@ -4,7 +4,7 @@ Bugs should be submitted to https://github.com/Botspot/pi-apps/issues
 NOTE: For best performance, we recommend a version like 1.12.2 + Optifine or the latest Minecraft with Optifabric or Sodium/Lithium/Phosphor Fabric Mods.
 
 Multiple Instance Minecraft Java Launcher for ARM
-To run: Menu -> Games -> MultiMC
+To run: Menu -> Games -> Multiple Instance Minecraft Java Launcher
 To run in a terminal: ~/MultiMC/install/MultiMC
 
 Link to the Raspberry Pi Forum Post: https://forums.raspberrypi.com/viewtopic.php?f=78&t=321888

--- a/apps/Minecraft Java MultiMC5/description
+++ b/apps/Minecraft Java MultiMC5/description
@@ -1,21 +1,20 @@
+Note: The upstream code for this launcher, MultiMC5, does not give support for custom builds
+Bugs should be submitted to https://github.com/Botspot/pi-apps/issues
+
 NOTE: For best performance, we recommend a version like 1.12.2 + Optifine or the latest Minecraft with Optifabric or Sodium/Lithium/Phosphor Fabric Mods.
 
-Minecraft Java MultiMC5 for the Raspberry Pi
+Multiple Instance Minecraft Java Launcher for ARM
 To run: Menu -> Games -> MultiMC
 To run in a terminal: ~/MultiMC/install/MultiMC
 
 Link to the Raspberry Pi Forum Post: https://forums.raspberrypi.com/viewtopic.php?f=78&t=321888
 
-The MultiMC5 Wiki can be found here: https://github.com/MultiMC/MultiMC5/wiki
+The Wiki for the upstream repo, MultiMC5, can be found here: https://github.com/MultiMC/MultiMC5/wiki
 If you need help installing Optifine: https://github.com/MultiMC/MultiMC5/wiki/MultiMC-and-OptiFine
 
-the MultiMC5 install script contains OS detection (ubuntu and debian/raspbian based systems supported), and automatic java 8, 11, and 16 download and installation
+The install script contains OS detection (ubuntu and debian/raspbian based systems supported), and automatic java 8, 11, and 16 download and installation
 
-MultiMC5 supports mojang, microsoft account login, and microsoft gamepass support, and minecraft versions from the old beta/alphas all the way up to 1.17+. Fabric and Forge mod loading is supported for the applicable minecraft versions
+The Launcher supports mojang, microsoft account login, and microsoft gamepass support, and minecraft versions from the old beta/alphas all the way up to 1.17+. Fabric and Forge mod loading is supported for the applicable minecraft versions
 
 A custom meta repo is used for arm32 and arm64 to provide lwjgl 2.9.4, 3.1.2(fake), 3.1.6, 3.2.1, 3.2.2, and 3.2.3(unused) native libraries. (https://github.com/theofficialgman/meta-multimc)
 This supports all currently released versions of minecraft.
-
-Note: MultiMC5 does not give support for custom builds
-
-If you have found a bug and it is re-producible on official MultiMC5 builds, then it can be submitted at https://github.com/MultiMC/MultiMC5/issues. Otherwise, bugs should be submitted to https://github.com/Botspot/pi-apps/issues

--- a/apps/Minecraft Java MultiMC5/install
+++ b/apps/Minecraft Java MultiMC5/install
@@ -198,7 +198,7 @@ set(Launcher_CommonName "MultiMC")
 set(Launcher_Copyright "MultiMC Contributors" PARENT_SCOPE)
 set(Launcher_Domain "multimc.org" PARENT_SCOPE)
 set(Launcher_Name "${Launcher_CommonName}" PARENT_SCOPE)
-set(Launcher_DisplayName "${Launcher_CommonName} 5" PARENT_SCOPE)
+set(Launcher_DisplayName "Multiple Instance Minecraft Java Launcher" PARENT_SCOPE)
 set(Launcher_UserAgent "${Launcher_CommonName}/5.0" PARENT_SCOPE)
 set(Launcher_ConfigFile "multimc.cfg" PARENT_SCOPE)
 set(Launcher_Git "https://github.com/MultiMC/Launcher" PARENT_SCOPE)
@@ -243,7 +243,8 @@ Type=Application
 Exec=env MESA_GL_VERSION_OVERRIDE=3.3 QT_AUTO_SCREEN_SCALE_FACTOR=0 $HOME/MultiMC/install/MultiMC
 Hidden=false
 NoDisplay=false
-Name=MultiMC
+Name=Multiple Instance Minecraft Java Launcher
+GenericName=MultiMC
 Icon=$HOME/.local/share/icons/MultiMC/icon-64.png
 Categories=Game
 _EOF_"
@@ -254,7 +255,8 @@ Type=Application
 Exec=$HOME/MultiMC/install/MultiMC
 Hidden=false
 NoDisplay=false
-Name=MultiMC
+Name=Multiple Instance Minecraft Java Launcher
+GenericName=MultiMC
 Icon=$HOME/.local/share/icons/MultiMC/icon-64.png
 Categories=Game
 _EOF_"

--- a/apps/Minecraft Java MultiMC5/install
+++ b/apps/Minecraft Java MultiMC5/install
@@ -153,7 +153,7 @@ mkdir -p build
 mkdir -p install
 
 # clone the complete source
-status "Downloading the MultiMC5 Source Code"
+status "Downloading the Source Code from https://github.com/MultiMC/Launcher.git"
 git clone --recursive https://github.com/MultiMC/Launcher.git src # You can clone from MultiMC's main repo, no need to use a fork.
 cd src
 git remote set-url origin https://github.com/MultiMC/Launcher.git
@@ -218,8 +218,8 @@ cd build
 rm -rf CMakeCache.txt
 status "Generating the CMake File"
 case "$arch" in
-    "64") cmake -DLauncher_EMBED_SECRETS=ON -DJAVA_HOME='/usr/lib/jvm/java-11-openjdk-arm64' -DLauncher_BUILD_PLATFORM="$model" -DLauncher_BUG_TRACKER_URL="https://github.com/Botspot/pi-apps/issues" -DLauncher_SUBREDDIT_URL="https://www.reddit.com/r/MultiMC/" -DLauncher_DISCORD_URL="https://discord.gg/multimc"  -DCMAKE_INSTALL_PREFIX=../install -DLauncher_META_URL:STRING="https://raw.githubusercontent.com/theofficialgman/meta-multimc/master-clean/index.json" ../src || error "cmake failed to generate" ;;
-    "32") cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLauncher_EMBED_SECRETS=ON -DJAVA_HOME='/usr/lib/jvm/java-11-openjdk-armhf' -DLauncher_BUILD_PLATFORM="$model" -DLauncher_BUG_TRACKER_URL="https://github.com/Botspot/pi-apps/issues" -DLauncher_SUBREDDIT_URL="https://www.reddit.com/r/MultiMC/" -DLauncher_DISCORD_URL="https://discord.gg/multimc"  -DCMAKE_INSTALL_PREFIX=../install -DLauncher_META_URL:STRING="https://raw.githubusercontent.com/theofficialgman/meta-multimc/master-clean-arm32/index.json" ../src || error "cmake failed to generate" ;;
+    "64") cmake -DLauncher_EMBED_SECRETS=ON -DJAVA_HOME='/usr/lib/jvm/java-11-openjdk-arm64' -DLauncher_BUILD_PLATFORM="$model" -DLauncher_BUG_TRACKER_URL="https://github.com/Botspot/pi-apps/issues" -DLauncher_DISCORD_URL="https://discord.gg/RXSTvaUvuu"  -DCMAKE_INSTALL_PREFIX=../install -DLauncher_META_URL:STRING="https://raw.githubusercontent.com/theofficialgman/meta-multimc/master-clean/index.json" ../src || error "cmake failed to generate" ;;
+    "32") cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLauncher_EMBED_SECRETS=ON -DJAVA_HOME='/usr/lib/jvm/java-11-openjdk-armhf' -DLauncher_BUILD_PLATFORM="$model" -DLauncher_BUG_TRACKER_URL="https://github.com/Botspot/pi-apps/issues" -DLauncher_DISCORD_URL="https://discord.gg/RXSTvaUvuu"  -DCMAKE_INSTALL_PREFIX=../install -DLauncher_META_URL:STRING="https://raw.githubusercontent.com/theofficialgman/meta-multimc/master-clean-arm32/index.json" ../src || error "cmake failed to generate" ;;
     *) error "Failed to detect OS CPU architecture! Something is very wrong." ;;
 esac
 
@@ -262,9 +262,8 @@ fi
 
 status_green 'Installation is now done! You can open the launcher by going to Menu > Games > MultiMC'
 
-warning "MultiMC5 does not give support for custom builds"
-warning "Only bugs that can be reproduced on official MultiMC5 builds should be posted to https://github.com/MultiMC/MultiMC5/issues"
+warning "The upstream, MultiMC5, does not give support for custom builds"
 warning "Bugs which only appear on this build should be posted to https://github.com/Botspot/pi-apps/issues or ask for help in the Discord Server"
 
-status "Make sure to visit the MultiMC5 wiki if this is your first time using the launcher: https://github.com/MultiMC/MultiMC5/wiki"
+status "Make sure to visit the upstream wiki if this is your first time using the launcher: https://github.com/MultiMC/MultiMC5/wiki"
 status "If you need help installing Optifine: https://github.com/MultiMC/MultiMC5/wiki/MultiMC-and-OptiFine"

--- a/apps/Minecraft Java MultiMC5/website
+++ b/apps/Minecraft Java MultiMC5/website
@@ -1,1 +1,1 @@
-https://github.com/cobalt2727/L4T-Megascript/blob/master/scripts/games_and_emulators/minecraft_java_multimc.sh
+https://github.com/Botspot/pi-apps


### PR DESCRIPTION
the install scripts folder has not been changed. That will need to be done later if necessary.
if the directory `apps/Minecraft Java MultiMC5` is to be renamed, consider renaming the "Lunar Client" to that name (or similar) and placing this launcher under "Minecraft Java"