### PR TITLE
update falkon install

### DIFF
--- a/apps/Falkon/install-32
+++ b/apps/Falkon/install-32
@@ -7,19 +7,10 @@ function error {
   exit 1
 }
 
-
-cd $HOME 
-
-( rm -f *libqt5webenginecore5* *libqt5webenginewidgets5* *falkon* || sudo rm -f *libqt5webenginecore5* *libqt5webenginewidgets5* *falkon* ) &> /dev/null
-
-# libqt5webenginecore5
-wget http://ftp.debian.org/debian/pool/main/q/qtwebengine-opensource-src/libqt5webenginecore5_5.11.3+dfsg-2+deb10u1_armhf.deb
-# libqt5webenginewidgets5
-wget http://ftp.debian.org/debian/pool/main/q/qtwebengine-opensource-src/libqt5webenginewidgets5_5.11.3+dfsg-2+deb10u1_armhf.deb
-# falkon
-wget http://ftp.debian.org/debian/pool/main/f/falkon/falkon_3.0.0-3_armhf.deb
-
-"${DIRECTORY}/pkg-install" "$HOME/libqt5webenginecore5_5.11.3+dfsg-2+deb10u1_armhf.deb $HOME/libqt5webenginewidgets5_5.11.3+dfsg-2+deb10u1_armhf.deb $HOME/falkon_3.0.0-3_armhf.deb" "$(dirname "$0")" || exit 1
-
-# Remove files after install
-( rm -f *libqt5webenginecore5* *libqt5webenginewidgets5* *falkon* || sudo rm -f *libqt5webenginecore5* *libqt5webenginewidgets5* *falkon* ) &> /dev/null
+# install falkon if its availabe in apt (debian/ubuntu have this but rpiOS/raspbian does not)
+package_available falkon
+if [[ $? == "0" ]]; then
+  install_packages falkon || error "Could not install falkon"
+else
+  install_packages "http://ftp.debian.org/debian/pool/main/q/qtwebengine-opensource-src/libqt5webenginecore5_5.11.3+dfsg-2+deb10u1_armhf.deb" "http://ftp.debian.org/debian/pool/main/q/qtwebengine-opensource-src/libqt5webenginewidgets5_5.11.3+dfsg-2+deb10u1_armhf.deb" "http://ftp.debian.org/debian/pool/main/f/falkon/falkon_3.0.0-3_armhf.deb" || error "Could not install falkon"
+fi

--- a/apps/Falkon/install-64
+++ b/apps/Falkon/install-64
@@ -7,19 +7,4 @@ function error {
   exit 1
 }
 
-
-cd $HOME 
-
-( rm -f *libqt5webenginecore5* *libqt5webenginewidgets5* *falkon* || sudo rm -f *libqt5webenginecore5* *libqt5webenginewidgets5* *falkon* ) &> /dev/null
-
-# libqt5webenginecore5
-wget http://ftp.debian.org/debian/pool/main/q/qtwebengine-opensource-src/libqt5webenginecore5_5.11.3+dfsg-2+deb10u1_arm64.deb
-# libqt5webenginewidgets5
-wget http://ftp.debian.org/debian/pool/main/q/qtwebengine-opensource-src/libqt5webenginewidgets5_5.11.3+dfsg-2+deb10u1_arm64.deb
-# falkon
-wget http://ftp.debian.org/debian/pool/main/f/falkon/falkon_3.0.0-3_arm64.deb
-
-"${DIRECTORY}/pkg-install" "$HOME/libqt5webenginecore5_5.11.3+dfsg-2+deb10u1_arm64.deb $HOME/libqt5webenginewidgets5_5.11.3+dfsg-2+deb10u1_arm64.deb $HOME/falkon_3.0.0-3_arm64.deb" "$(dirname "$0")" || exit 1
-
-# Remove files after install
-( rm -f *libqt5webenginecore5* *libqt5webenginewidgets5* *falkon* || sudo rm -f *libqt5webenginecore5* *libqt5webenginewidgets5* *falkon* ) &> /dev/null
+install_packages falkon || error "Could not install falkon"

--- a/apps/Falkon/uninstall
+++ b/apps/Falkon/uninstall
@@ -7,10 +7,4 @@ function error {
   exit 1
 }
 
-reduceapt() { #remove unwanted lines from apt output
-  grep -v "apt does not have a stable CLI interface.\|Reading package lists...\|Building dependency tree\|Reading state information...\|Need to get\|After this operation,\|Get:\|Fetched\|Selecting previously unselected package\|Preparing to unpack\|Unpacking \|Setting up \|Processing triggers for "
-}
-
-"${DIRECTORY}/purge-installed" "$(dirname "$0")" || exit 0
-
-sudo apt purge falkon -y 2>&1 | reduceapt || error "Failed to purge packages!"
+purge_packages || error "Dependencies failed to uninstall"


### PR DESCRIPTION
32bit pisOS/raspbian do not have the falcon package, so keep using the manual package/dependency grab method

other OSs (such as 64bit piOS and debian/ubuntu 32/64bit do have the package, so install normally there)

resolves https://github.com/Botspot/pi-apps/issues/1155