### PR TITLE
print human readable date in addition to seconds since 1970

### DIFF
--- a/manage
+++ b/manage
@@ -49,7 +49,8 @@ if [ $(date +%s) -gt $(($current_git_date + 7776000)) ];then
   rm -rf ~/pi-apps-forced-update
   git clone "$(cat "${DIRECTORY}/etc/git_url")" pi-apps-forced-update 1>&2 && cp -af "${DIRECTORY}/data" ~/pi-apps-forced-update && mv -f "$DIRECTORY" "${DIRECTORY}-3-months-old" && mv -f ~/pi-apps-forced-update "${DIRECTORY}"
   temp_logfile="$(mktemp).txt"
-  echo -e "Updated a 3-months-outdated pi-apps install.\nFrom: $current_git_date\nTo: $(cd "$DIRECTORY"; git show -s --format=%ct)\n$(get_device_info)" >> "$temp_logfile"
+  new_git_date="$(cd "$DIRECTORY"; git show -s --format=%ct)"
+  echo -e "Updated a 3-months-outdated pi-apps install.\nFrom: $(date -d@$current_git_date); $current_git_date\nTo:   $(date -d@$new_git_date); $new_git_date\n$(get_device_info)" >> "$temp_logfile"
   send_error_report "$temp_logfile" 1>&2
   rm -f "$temp_logfile"
   sleep 10


### PR DESCRIPTION
output will look something like below (the lines will match up in bash)
```
Updated a 3-months-outdated pi-apps install.
From: Sat Nov 13 16:35:33 EST 2021; 1636839333
To:   Fri Nov  5 17:43:27 EDT 2021; 1636148607
```

I honestly just got bothered with only seeing the seconds in logs