### PR TITLE
get the master date from github repo instead of system clock

### DIFF
--- a/manage
+++ b/manage
@@ -42,7 +42,7 @@ upstream_git_date="$(curl https://api.github.com/repos/Botspot/pi-apps/commits/m
 if ! [[ "$upstream_git_date" =~ ^[0-9]+$ ]]; then
   # if upstream master git date can't be found, then fallback to local time server
   # the above checks for an empty variable or a variable containing non-numerical values
-  echo "Falling back to local system time"
+  echo "Falling back to local system time" 1>&2
   upstream_git_date="$(date +%s)"
 fi
 current_git_date="$(cd "$DIRECTORY"; git show -s --format=%ct)"

--- a/manage
+++ b/manage
@@ -38,8 +38,15 @@ EOF
 
 #Silently re-download repo if github repository is over 3 months out of date
 {
+upstream_git_date="$(curl https://api.github.com/repos/Botspot/pi-apps/commits/master 2>&1 | grep '"date":' | tail -n 1 | sed 's/"date"://g' | xargs date +%s -d)"
+if ! [[ "$upstream_git_date" =~ ^[0-9]+$ ]]; then
+  # if upstream master git date can't be found, then fallback to local time server
+  # the above checks for an empty variable or a variable containing non-numerical values
+  echo "Falling back to local system time"
+  upstream_git_date="$(date +%s)"
+fi
 current_git_date="$(cd "$DIRECTORY"; git show -s --format=%ct)"
-if [ $(date +%s) -gt $(($current_git_date + 7776000)) ];then
+if [ "$upstream_git_date" -gt $(($current_git_date + 7776000)) ];then
   yad --window-icon="${DIRECTORY}/icons/logo.png"  --width=500 --no-buttons --center --title="Auto-updating Pi-Apps" \
     --text="Your Pi-Apps github repository is somehow 3 months out-of-date."$'\n'"Downloading fresh version of pi-apps and saving the old version to ${DIRECTORY}-3-months-old..." &
   sleep 1


### PR DESCRIPTION
uses system clock as a fallback incase the github repo time is invalid or missing