### PR TITLE
update multimc5 version and add java 17

### DIFF
--- a/apps/Minecraft Java MultiMC5/install
+++ b/apps/Minecraft Java MultiMC5/install
@@ -74,6 +74,7 @@ case "$__os_id" in
                 hash -r
                 mkdir -p ~/MultiMC/install/java || exit 1
                 cd ~/MultiMC/install/java || exit 1
+                # download java 8 (unavailable in some debian versions)
                 rm -rf jdk8u302-b08
                 rm -rf java-8-temurin-aarch64
                 rm -rf OpenJDK8U-jdk_aarch64_linux_hotspot_8u302b08.tar.gz
@@ -82,6 +83,16 @@ case "$__os_id" in
                 rm -rf OpenJDK8U-jdk_aarch64_linux_hotspot_8u302b08.tar.gz
                 # check if java is working and remove if broken
                 ./java-8-temurin-aarch64/bin/java -version || ( warning "The downloaded java 8 version does not work, removing it now..." && warning "It is up to you to download and install a working java 8 version." && echo "" && warning "Continuing the MultiMC5 Install without Java 8" && rm -rf java-8-temurin-aarch64 )
+
+                # download java 17 (unavailable in some debian versions)
+                rm -rf jdk-17.0.1+12
+                rm -rf java-17-temurin-aarch64
+                rm -rf OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.1_12.tar.gz
+                wget https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.1_12.tar.gz && tar -xzf OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.1_12.tar.gz
+                mv jdk-17.0.1+12 java-17-temurin-aarch64
+                rm -rf OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.1_12.tar.gz
+                # check if java is working and remove if broken
+                ./java-17-temurin-aarch64/bin/java -version || ( warning "The downloaded java 17 version does not work, removing it now..." && warning "It is up to you to download and install a working java 17 version." && echo "" && warning "Continuing the MultiMC5 Install without Java 17" && rm -rf java-17-temurin-aarch64 )
                 cd ~
                 ;;
             "32") 
@@ -89,6 +100,7 @@ case "$__os_id" in
                 hash -r
                 mkdir -p ~/MultiMC/install/java || exit 1
                 cd ~/MultiMC/install/java || exit 1
+                # download java 8 (unavailable or broken in some debian versions)
                 rm -rf jdk8u302-b08-aarch32-20210726
                 rm -rf java-8-temurin-armhf
                 rm -rf OpenJDK8U-jdk_arm_linux_hotspot_8u302b08.tar.gz
@@ -97,6 +109,17 @@ case "$__os_id" in
                 rm -rf OpenJDK8U-jdk_arm_linux_hotspot_8u302b08.tar.gz
                 # check if java is working and remove if broken
                 ./java-8-temurin-armhf/bin/java -version || ( warning "The downloaded java 8 version does not work, removing it now..." && warning "It is up to you to download and install a working java 8 version." && echo "" && warning "Continuing the MultiMC5 Install without Java 8" && rm -rf java-8-temurin-armhf )
+
+                # download java 17 (unavailable in some debian versions)
+                rm -rf jdk-17.0.1+12
+                rm -rf java-17-temurin-armhf
+                rm -rf OpenJDK17U-jdk_arm_linux_hotspot_17.0.1_12.tar.gz
+                wget https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_arm_linux_hotspot_17.0.1_12.tar.gz && tar -xzf OpenJDK17U-jdk_arm_linux_hotspot_17.0.1_12.tar.gz
+                mv jdk-17.0.1+12 java-17-temurin-armhf
+                rm -rf OpenJDK17U-jdk_arm_linux_hotspot_17.0.1_12.tar.gz
+                # check if java is working and remove if broken
+                ./java-17-temurin-armhf/bin/java -version || ( warning "The downloaded java 17 version does not work, removing it now..." && warning "It is up to you to download and install a working java 17 version." && echo "" && warning "Continuing the MultiMC5 Install without Java 17" && rm -rf java-17-temurin-armhf )
+                
                 cd ~
                 ;;
             *) error "Failed to detect OS CPU architecture! Something is very wrong." ;;
@@ -129,7 +152,7 @@ case "$__os_id" in
                 ;;
         esac
         # install dependencies
-        install_packages build-essential libopenal1 x11-xserver-utils git clang cmake curl zlib1g-dev openjdk-8-jre openjdk-11-jdk openjdk-16-jre qtbase5-dev || error "Failed to install dependencies"
+        install_packages build-essential libopenal1 x11-xserver-utils git clang cmake curl zlib1g-dev openjdk-8-jre openjdk-17-jre openjdk-11-jdk openjdk-16-jre qtbase5-dev || error "Failed to install dependencies"
         hash -r
         ;;
     *)
@@ -150,7 +173,7 @@ cd src
 git remote set-url origin https://github.com/MultiMC/Launcher.git
 git checkout --recurse-submodules develop || error "Could not checkout develop branch"
 git pull --recurse-submodules || error "Could Not Pull Latest MultiMC Source Code, verify your ~/MultiMC/src directory hasn't been modified. You can detete the  ~/MultiMC/src folder to attempt to fix this error."
-git checkout --recurse-submodules 25fbeb265a368b16354d5e44887508121766c45a || error "Could Not Checkout MultiMC Source Code commit, verify your ~/MultiMC/src directory hasn't been modified. You can detete the  ~/MultiMC/src folder to attempt to fix this error."
+git checkout --recurse-submodules 0022aed8bb03c21ca6828092f7f4c5655699f9a9 || error "Could Not Checkout MultiMC Source Code commit, verify your ~/MultiMC/src directory hasn't been modified. You can detete the  ~/MultiMC/src folder to attempt to fix this error."
 # add secrets files
 mkdir -p secrets
 tee secrets/Secrets.h <<'EOF' >>/dev/null


### PR DESCRIPTION
(necessary for minecraft 1.18 prerelease 2 and later)
@Itai-Nelken @Botspot 
current version works fine, but most users won't have java 17 already installed.
as is the norm, we can't use raspbian repos (since they don't have java 17) and buster is also missing java 17 in general

so all debian versions get tar.gz from temurin