### PR TITLE
Update tip for uploading files in app-request issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/app-request.yml
+++ b/.github/ISSUE_TEMPLATE/app-request.yml
@@ -32,7 +32,7 @@ body:
     attributes:
       label: Upload file
       description: "If you have a deb of the app, or if you've created a zip file for this app, or if you have any other relevant files, upload it here."
-      placeholder: "Tips: You can upload files to transfer.sh and paste the link here"
+      placeholder: "Tips: You can upload files by here by clicking to expand the regular text-box"
     validations:
       required: false
       

--- a/.github/ISSUE_TEMPLATE/app-request.yml
+++ b/.github/ISSUE_TEMPLATE/app-request.yml
@@ -41,6 +41,8 @@ body:
     attributes:
       label: Confirmations
       options:
+        - label: I have confirmed that this app is legal and not piracy.
+          required: true
         - label: I have confirmed that this app has never been discussed in https://github.com/Botspot/pi-apps/issues and https://github.com/Botspot/pi-apps/pulls, and it is not in the Pi Apps app list.
           required: true
         - label: I have confirmed that this app can run on Raspberry Pi.


### PR DESCRIPTION
This isn't the best way to put it. but what I mean is that you can click on the text box to expand the regular github one and then you can upload files (not tested, but I see no reason for it not to work).