### PR TITLE
Fix bleachbit desktop shortcut path

### DIFF
--- a/apps/BleachBit/install
+++ b/apps/BleachBit/install
@@ -3,4 +3,4 @@
 install_packages https://download.bleachbit.org/bleachbit_4.4.2-0_all_debian11.deb || exit 1
 
 # Move BleachBit to Accessories category
-sudo sed -i s/"Categories=System;FileTools;GTK;"/"Categories=Utility"/g /usr/share/applications/org.bleachbit.BleachBit.desktop /usr/share/applications/org.bleachbit.BleachBit-root.desktop  || error "Failed to move BleachBit to Accessories category."
+sudo sed -i s/"Categories=System;FileTools;GTK;"/"Categories=Utility"/g /usr/share/applications/bleachbit-root.desktop  || error "Failed to move BleachBit to Accessories category."


### PR DESCRIPTION
Installed bleachbit, and apprantly in newest deb they renamed the desktop shortcut. Also the non-root shortcut was removed apprantly.