### PR TITLE
Update XSnow to 3.3.3 and add `install-64`

### DIFF
--- a/apps/XSnow/install-32
+++ b/apps/XSnow/install-32
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-install_packages https://www.ratrabbit.nl/downloads/xsnow/xsnow_3.3.2-1_armhf.deb || exit 1 
+install_packages https://www.ratrabbit.nl/downloads/xsnow/xsnow_3.3.3-1_armhf.deb || exit 1

--- a/apps/XSnow/install-64
+++ b/apps/XSnow/install-64
@@ -1,4 +1,3 @@
 !#/bin/bash
 
-install_packages || exit 1 
-
+install_packages https://www.ratrabbit.nl/downloads/xsnow/xsnow_3.3.3-1_arm64.deb || exit 1 

--- a/apps/XSnow/install-64
+++ b/apps/XSnow/install-64
@@ -1,0 +1,4 @@
+!#/bin/bash
+
+install_packages || exit 1 
+

--- a/apps/XSnow/website
+++ b/apps/XSnow/website
@@ -1,1 +1,1 @@
-https://sourceforge.net/projects/xsnow
+https://www.ratrabbit.nl/ratrabbit/xsnow/


### PR DESCRIPTION
After some discussions and testing with the maintainer of XSnow, the official arm64 DEB is finally ﻿ready now and hosted on the official website.   **:)**

I have tested it on arm64 bullseye and buster (on vdesktop), and it works well. 