### PR TITLE
Removed apt checkbox on issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/app-request.yml
+++ b/.github/ISSUE_TEMPLATE/app-request.yml
@@ -47,5 +47,3 @@ body:
           required: true
         - label: I have confirmed that this app can run on Raspberry Pi.
           required: true
-        - label: I have confirmed that this app is not installable with `apt`, or the app is the updated version of APT one.
-          required: true


### PR DESCRIPTION
You can now submit also apt packages so yyou don't need to say the app is no apt package