### PR TITLE
Update Github-CLI to 2.3.0

### DIFF
--- a/apps/Github-CLI/install-32
+++ b/apps/Github-CLI/install-32
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION='2.2.0'
+VERSION='2.3.0'
 
 install_packages https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_armv6.deb || exit 1
 

--- a/apps/Github-CLI/install-64
+++ b/apps/Github-CLI/install-64
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION='2.2.0'
+VERSION='2.3.0'
 
 install_packages https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_arm64.deb || exit 1
 


### PR DESCRIPTION
- Add `-q` flag to suppress output
- update multimc5 version and add java 17
- Cura: add mimetype and libgles-dev
- BUGFIX: ensure apt-utils is installed
- Redirect to /dev/null when `rm -rf ~/CommanderPi`
- Redirect to /dev/null when `rm -rf ~/CommanderPi`
- manage: simplify 3-month-forced-update procedure
- FF Multi Converter: uninstall: remove menu button
- Godot: enable OpenGL with MESA_GL_VERSION_OVERRIDE=3.3
- api: repo_refresh: remove "./" from local-repo Packages file
- Update Discord to 2.1.1 (#1185)
- Create install-64
- Remove white background from categories/Installed.png
- QEMU: update to v6.1.50 (#1187)
- FreeTube: update to v0.15.1 (#1188)
- Update turbowarp to v0.12.0 (#1190)
- Sublime Text: install-64: use install_packages
- api: add checks for more download errors
- updater: change message to "No files can be updated." to close #1194
- Issue forms (#1196)
- Updated clamtk to v6.14 (#1197)
- Make `/usr/local/bin/deskreen` executable, store appimage in `$HOME/.Deskreen/` (#1200)
- Update Bleachbit to 4.4.2, use official deb, use sudo when removing/`sed`ing file, don't remove `BleachBit as Administrator` menu shortcut (#1198)
- codex: migrate links
- amiberry: migrate links
- update tor-browser links
- alacritty: migrate to files repo
- Btop++: uninstall: remove menu button
- Update Discord to 2.1.2 (#1208)
- Update Drawing to 0.8.4 (#1209)
- Update README.md
- Update README.md
- Update download link
- Update to 3.3.3, add install-64 and update website
- update etcher to v1.7.0
- Update mc bedrock to #678 (#1214)
- is_supported_system( ): Add `-i` flag to ignore case (#1221)
- update turbowarp to v0.13.0
- Windows Flasher: bump app, add missing udftools dependency
- Slight improvements to vector/logo.svg
- PrusaSlicer: update release to be compatible with Bullseye
- update multimc launcher to latest (#1226)
- Update to YML link
- Update tip for uploading files in app-request issue form (#1207)
- Fix bleachbit desktop shortcut path (#1213)
- Tor: retain configuration when reinstalling
- PrusaSlicer: remove unnecessary libwxgtk3.0-dev dependency
- api: add checks for repo-suite-change, sudo, libaria2, systemd
- auto update Vivaldi (#1184)
- createapp, preload, preload-daemon: fully support package-apps
- Add 9 package-apps
- Add GIMP package-app to close #1229
- Add Filezilla app
- get_icon_from_package: fix search algorithm
- Improve comparing fork and upstream, added `Imported` category and fix bugs (#1181)
- update OpenSCAD to avoid segmentation fault
- LibrePCB: fix desktop shortcut
- LibreOffice: switch from gtk2 to gtk3
- Bleachbit: fix moving to Accessories category
- Removed apt line on issue template (#1231)
- Add Caprine app (#1215)
- Update to 2.1.3
- Update to 2.1.3
- Update Github-CLI to 2.3.0
- Update Github-CLI to 2.3.0
