### PR TITLE
Update FreeTube download link

### DIFF
--- a/apps/FreeTube/install-32
+++ b/apps/FreeTube/install-32
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-install_packages https://apt.raspbian-addons.org/debian/pool/freetube_0.15.1_armv7l.deb || exit 1
+install_packages https://apt.raspbian-addons.org/debian/pool/main/f/freetube/freetube_0.15.1_armhf.deb || exit 1
 

--- a/apps/FreeTube/install-64
+++ b/apps/FreeTube/install-64
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-install_packages https://apt.raspbian-addons.org/debian/pool/freetube_0.15.1_arm64.deb || exit 1
+install_packages https://apt.raspbian-addons.org/debian/pool/main/f/freetube/freetube_0.15.1_arm64.deb || exit 1
 


### PR DESCRIPTION
Fix Discord error report.

I don't know why the link path is changed in https://apt.raspbian-addons.org. 