### PR TITLE
automatic apps list wiki page

### DIFF
--- a/.github/workflows/update-wiki.sh
+++ b/.github/workflows/update-wiki.sh
@@ -1,0 +1,48 @@
+conversion() {
+
+    readarray -t categories < <(cat $GITHUB_WORKSPACE/etc/categories | sed 's/$/|/g' | awk -F'|' '{print $2}' | sort - | uniq)
+    readarray -t script_name < <(cat $GITHUB_WORKSPACE/etc/categories | sed 's/$/|/g' | awk -F'|' '{print $1}')
+    readarray -t script_category < <(cat $GITHUB_WORKSPACE/etc/categories | sed 's/$/|/g' | awk -F'|' '{print $2}')
+
+    for category in "${categories[@]}"; do
+        if [[ "$category" == "hidden" ]]; then
+            continue
+        fi
+        echo "# $category"
+        iter=0
+        for script in "${script_name[@]}"; do
+            if [[ "${script_category[$iter]}" == "$category" ]] && [[ -a "$GITHUB_WORKSPACE/apps/$script" ]]; then
+
+                # determine if app is arm64, arm32, or both
+                if [[ -a "$GITHUB_WORKSPACE/apps/$script/install" ]]; then
+                    arch="ARM32/ARM64"
+                elif [[ -a "$GITHUB_WORKSPACE/apps/$script/install-32" ]]; then
+                    if [[ -a "$GITHUB_WORKSPACE/apps/$script/install-64" ]]; then
+                        arch="ARM32/ARM64"
+                    else
+                        arch="ARM32 ONLY"
+                    fi
+                elif [[ -a "$GITHUB_WORKSPACE/apps/$script/install-64" ]]; then
+                    arch="ARM64 ONLY"
+                else
+                    arch="Package app"
+                fi
+                script_website=$(cat "$GITHUB_WORKSPACE/apps/$script/website" 2>/dev/null)
+                script_credits=$(cat "$GITHUB_WORKSPACE/apps/$script/credits" 2>/dev/null)
+                echo ""
+                script_url=$(echo $script | sed -e 's/ /%20/g')
+                echo "### <img src=https://github.com/Botspot/pi-apps/blob/master/apps/$script_url/icon-64.png height=32> ***[$script](https://github.com/Botspot/pi-apps/tree/master/apps/$script_url)***"
+                [[ ! -z "$script_website" ]] && [[ ! -z "$script_credits" ]] && echo "$script_website - $script_credits<br />"
+                [[ ! -z "$script_website" ]] && [[ -z "$script_credits" ]] && echo "$script_website<br />"
+                [[ -z "$script_website" ]] && [[ ! -z "$script_credits" ]] && echo "$script_credits<br />"
+                echo "$arch"
+                echo ""
+                cat "$GITHUB_WORKSPACE/apps/$script/description" | sed -e "s/.*/    &/"
+            fi
+            iter=$(($iter + 1))
+        done
+    done
+
+}
+
+conversion > Apps-List.md

--- a/.github/workflows/update_wiki.yml
+++ b/.github/workflows/update_wiki.yml
@@ -1,0 +1,52 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Update_Wiki_Scripts
+
+# Controls when the workflow will run
+on:
+  # triggers the action when megascript_apps.txt file is updated
+  push:
+    paths:
+      - 'etc/categories'
+      - 'apps/**/description'
+      - 'apps/**/website'
+      - '.github/workflows/update-wiki.sh'
+      - '.github/workflows/update_wiki.yml'
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  update-wiki:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          chmod +x $GITHUB_WORKSPACE/.github/workflows/update-wiki.sh
+          cd $GITHUB_WORKSPACE
+          mkdir wikioutput
+          cd wikioutput
+          $GITHUB_WORKSPACE/.github/workflows/update-wiki.sh
+          cat Apps-List.md
+          
+      - name: "Set environmental variables"
+        run: |
+          echo "ACTION_MAIL=Botspot@users.noreply.github.com" >> $GITHUB_ENV
+          echo "ACTION_NAME=Botspot" >> $GITHUB_ENV
+          echo "OWNER=Botspot" >> $GITHUB_ENV
+          echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
+      
+      - name: Upload scripts page to wiki
+        uses: docker://decathlon/wiki-page-creator-action:latest
+        env:
+          GH_PAT: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          MD_FOLDER: "/github/workspace/wikioutput"         

--- a/apps/Geekbench/website
+++ b/apps/Geekbench/website
@@ -1,1 +1,1 @@
-geekbench.com
+https://www.geekbench.com/

--- a/apps/Processing IDE/website
+++ b/apps/Processing IDE/website
@@ -1,1 +1,1 @@
-processing.org
+https://processing.org/

--- a/apps/Turbowarp/website
+++ b/apps/Turbowarp/website
@@ -1,1 +1,1 @@
-turbowarp.org
+https://turbowarp.org/


### PR DESCRIPTION
with pi-apps growing to a large number of apps. I figured it would be helpful for users if the current appslist was available on the wiki

this scripting is still in the works and there probably will be changes before I open it up for merging

dropping these links here for my future reference: 
https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet