### PR TITLE
box64: use /usr/share/keyrings

### DIFF
--- a/apps/Box64/install-64
+++ b/apps/Box64/install-64
@@ -5,7 +5,7 @@ if [ $? != 0 ];then
   error "Failed to add box64.list file!"
 fi
 
-wget -qO- https://ryanfortner.github.io/box64-debs/KEY.gpg | sudo apt-key add -
+wget -O- https://ryanfortner.github.io/box64-debs/KEY.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/box64-debs-archive-keyring.gpg 
 if [ $? != 0 ];then
   sudo rm -f /etc/apt/sources.list.d/box64.list
   error "Failed to add KEY.gpg to APT keyring!"

--- a/apps/Box64/uninstall
+++ b/apps/Box64/uninstall
@@ -3,4 +3,4 @@ purge_packages || exit 1
 
 sudo rm -f /etc/apt/sources.list.d/box64.list || error "Failed to remove repo!"
 
-sudo apt-key del "DF9A 1B85 23C3 2EEE FF2A  6CDA 7759 FA1D 9FEC AC9E" || error "Failed to remove GPG key!"
+sudo rm -f /usr/share/keyrings/box64-debs-archive-keyring.gpg || error "Failed to remove GPG key!"


### PR DESCRIPTION
Similar to https://github.com/raspbian-addons/raspbian-addons/issues/139, apt-key is deprecated in bullseye, so it won't work in the future. An alternative method is to place the key in `/usr/share/keyrings` and specify the key file in `/etc/apt/sources.list.d/box64.list`.