### PR TITLE
Remove duplicated Blockbench category and move Blockbench to Editors

### DIFF
--- a/etc/categories
+++ b/etc/categories
@@ -10,8 +10,7 @@ AstroMenace|Games
 Autostar|Tools
 BalenaEtcher|Tools
 BleachBit|Tools
-BlockBench|Games
-BlockBench|Tools
+BlockBench|Editors
 BlockPi|Editors
 Bongo Cam|Multimedia
 Box64|Tools


### PR DESCRIPTION
I think Blockbench should be in `Editors` instead of `Games` or `Tools`.