### PR TITLE
Use `python3-psutil` 

### DIFF
--- a/apps/SysMonTask/install
+++ b/apps/SysMonTask/install
@@ -1,6 +1,3 @@
 #!/bin/bash
 
-install_packages https://apt.raspbian-addons.org/debian/pool/main/s/sysmontask/sysmontask_1.3.9-ubuntu20.10_all.deb || exit 1
-
-pip3 install -U psutil || error "Failed to upgrade psutil"
-
+install_packages https://apt.raspbian-addons.org/debian/pool/main/s/sysmontask/sysmontask_1.3.9-ubuntu20.10_all.deb python3-psutil || exit 1


### PR DESCRIPTION
That is my habit - always install Python modules from APT. If the module isn't in the APT repo, then install from `pip`.

Installing Python modules from pip is sometimes unstable, especially in Raspberry Pi.
 (e.g. `pygame` module from pip detects Raspberry Pi as WIndows...)

`psutil` is a popular module, hence `python3-psutil` is in most repositories. (At least in Ubuntu and Raspbian's repo)

See [this](https://linuxize.com/post/how-to-install-pip-on-ubuntu-18.04/#:~:text=When%20installing%20python%20modules%20globally,work%20properly%20on%20Ubuntu%20systems.&text=This%20way%20you%20do%20not,about%20affecting%20other%20Python%20projects.) and [this](https://askubuntu.com/a/116645).