### PR TITLE
Replace 🭸 with - and hide cursor

### DIFF
--- a/api
+++ b/api
@@ -1747,10 +1747,10 @@ wget() { #Intercept all wget commands. When possible, uses aria2c.
         
         #check if this line is a progress-stat line, like: "[#a6567f 20MiB/1.1GiB(1%) CN:16 DL:14MiB ETA:1m19s]"
         if [[ "$line" == '['*']' ]];then
-
+          
           #hide cursor
           printf "\033[?25l"
-
+          
           #print the total data only, like: "1.1GiB/1.1GiB"
           statsline="$(echo "$line" | awk '{print $2}' | sed 's/(.*//g' | tr -d '\n') "
           #get the length of statsline
@@ -1772,7 +1772,7 @@ wget() { #Intercept all wget commands. When possible, uses aria2c.
           
           statsline+="\e[92m$(for ((i=0; i<$progress_characters; i++)); do echo -ne "\e[1m—"; done)\e[39m" # other possible characters to put here: █🭸
           echo -ne "\e[0K${statsline}\r\033\e[0m" #clear and print over previous line
-
+          
           #reduce the line and print over the previous line, like: "1.1GiB/1.1GiB(98%) DL:18MiB"
           #echo "$line" | awk '{print $2 " " $4 " " substr($5, 1, length($5)-1)}' | tr -d '\n'
           

--- a/api
+++ b/api
@@ -1747,10 +1747,12 @@ wget() { #Intercept all wget commands. When possible, uses aria2c.
         
         #check if this line is a progress-stat line, like: "[#a6567f 20MiB/1.1GiB(1%) CN:16 DL:14MiB ETA:1m19s]"
         if [[ "$line" == '['*']' ]];then
-          
-          
+
+          #hide cursor
+          printf "\033[?25l"
+
           #print the total data only, like: "1.1GiB/1.1GiB"
-          statsline=" $(echo "$line" | awk '{print $2}' | sed 's/(.*//g' | tr -d '\n') "
+          statsline="$(echo "$line" | awk '{print $2}' | sed 's/(.*//g' | tr -d '\n') "
           #get the length of statsline
           characters_subtract=${#statsline}
           
@@ -1768,9 +1770,9 @@ wget() { #Intercept all wget commands. When possible, uses aria2c.
           #determine how many characters in progress bar to light up
           progress_characters=$(((percent*available_width)/100))
           
-          statsline+="\e[92m$(for ((i=0; i<$progress_characters; i++)); do printf "🭸"; done)\e[39m" # other possible characters to put here: █—🭸
-          echo -ne "\e[0K${statsline}\r\033" #clear and print over previous line
-          
+          statsline+="\e[92m$(for ((i=0; i<$progress_characters; i++)); do echo -ne "\e[1m—"; done)\e[39m" # other possible characters to put here: █🭸
+          echo -ne "\e[0K${statsline}\r\033\e[0m" #clear and print over previous line
+
           #reduce the line and print over the previous line, like: "1.1GiB/1.1GiB(98%) DL:18MiB"
           #echo "$line" | awk '{print $2 " " $4 " " substr($5, 1, length($5)-1)}' | tr -d '\n'
           
@@ -1784,6 +1786,8 @@ wget() { #Intercept all wget commands. When possible, uses aria2c.
     local exitcode=${PIPESTATUS[0]}
   fi
   
+  #show cursor
+  printf "\033[?25h"
   #display a "download complete" message
   if [ $exitcode == 0 ] && [ "$quiet" == 0 ];then
     echo

--- a/api
+++ b/api
@@ -1735,7 +1735,7 @@ wget() { #Intercept all wget commands. When possible, uses aria2c.
       echo '--quiet'
     fi
     
-    terminal_width="$(tput cols)"
+    terminal_width="$(tput cols || exho 80)"
     
     #run aria2c and reduce its output.
     aria2c "${aria2_flags[@]}" | while read -r line ;do
@@ -1770,7 +1770,7 @@ wget() { #Intercept all wget commands. When possible, uses aria2c.
           #determine how many characters in progress bar to light up
           progress_characters=$(((percent*available_width)/100))
           
-          statsline+="\e[92m$(for ((i=0; i<$progress_characters; i++)); do echo -ne "\e[1m—"; done)\e[39m" # other possible characters to put here: █🭸
+          statsline+="\e[92m\e[1m$(for ((i=0; i<$progress_characters; i++)); do printf "—"; done)\e[39m" # other possible characters to put here: █🭸
           echo -ne "\e[0K${statsline}\r\033\e[0m" #clear and print over previous line
           
           #reduce the line and print over the previous line, like: "1.1GiB/1.1GiB(98%) DL:18MiB"
@@ -1854,4 +1854,3 @@ elif [ -z "$DIRECTORY" ] || [ "$DIRECTORY" == "$HOME" ] || [ ! -d "$DIRECTORY" ]
 fi
 
 export DIRECTORY
-


### PR DESCRIPTION
🭸 needs emoji font to be installed, so some systems without emoji font installed will get something weird like this:

![](https://i.imgur.com/NezKfhA.png)

`-` looks the same with  🭸 after bold.