### PR TITLE
Reset `GTK_THEME` when open text editor

### DIFF
--- a/api
+++ b/api
@@ -1575,7 +1575,7 @@ text_editor() { #Open user-preferred text editor. $1 is file to open
     "${DIRECTORY}/etc/terminal-run" "nano "\""$1"\""" "Editing $(basename "$1")"
   else
     #non-terminal text editor
-    "$preferrededitor" "$1"
+    GTK_THEME='' "$preferrededitor" "$1"
   fi
 }
 


### PR DESCRIPTION
To let text editors follow the system GTK theme.