### PR TITLE
min: update to v1.22.2

### DIFF
--- a/apps/Min/install-32
+++ b/apps/Min/install-32
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-install_packages https://github.com/ryanfortner/minbrowser-arm-builds/releases/download/1.22.1/min_1.22.1_armhf.deb || exit 1
+install_packages https://github.com/minbrowser/min/releases/download/v1.22.2/min_1.22.2_armhf.deb || exit 1
 

--- a/apps/Min/install-64
+++ b/apps/Min/install-64
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-install_packages https://github.com/minbrowser/min/releases/download/v1.22.1/min_1.22.1_arm64.deb || exit 1
+install_packages https://github.com/minbrowser/min/releases/download/v1.22.2/min_1.22.2_arm64.deb || exit 1
 


### PR DESCRIPTION
Starting with v1.22.2, the official min repo provides raspberry pi builds (see https://github.com/minbrowser/min/pull/1813).