### PR TITLE
Api update (install_packages and failed installs)

### DIFF
--- a/api
+++ b/api
@@ -427,18 +427,7 @@ Package: $package_name" > ~/$package_name/DEBIAN/control
   
   #install dummy deb
   {
-  #If this app's dummy deb is already insalled, uninstall it
-  if package_installed "$package_name" ;then
-    status "Reinstalling the $package_name package..."
-    apt_lock_wait
-    local output="$(sudo -E apt purge -y $package_name 2>&1 | less_apt | tee /dev/stderr)"
-    if [ $? != 0 ];then
-      echo "$output"
-      error "Failed to purge dummy deb ($package_name)"
-    fi
-  else
-    status "Installing the $package_name package..."
-  fi
+  status "Installing the $package_name package..."
   
   apt_lock_wait
   local output="$(sudo -E apt install -fy --no-install-recommends --allow-downgrades "${apt_flags[@]}" ~/$package_name.deb 2>&1 | less_apt | tee /dev/stderr)"

--- a/manage
+++ b/manage
@@ -277,14 +277,22 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
   else #if app failed to install/uninstall
 
     #remove dummy deb if app failed to install (to avoid dummy debs being left on a users install for broken apps)
-    if [[ ${mode} == "install" ]] && [[ "$(app_type "$app")" == standard ]]; then
-      local package_name="$(app_to_pkgname "$app")"
-      local output="$(sudo -E apt purge -y $package_name 2>&1 | less_apt | tee /dev/stderr)"
-      if [ $? != 0 ];then
-        echo "$output"
-        warning "Failed to purge dummy deb ($package_name)"
+    package_name="$(app_to_pkgname "$app")"
+    if [[ ${mode} == "install" ]] && [[ "$(app_type "$app")" == standard ]] && package_installed "$package_name"; then
+      if [[ "$script_input" == "update" ]]; then
+        #if install failed as part of an update, don't autoremove the packages, only purge the dummy deb
+        output="$(sudo -E apt purge -y $package_name 2>&1 | less_apt | tee /dev/stderr)"
+        if [ $? != 0 ];then
+          echo "$output"
+          warning "Failed to purge dummy deb ($package_name)"
+        fi
+        unset output
+      else
+        #install and not update failed, run purge_packages
+        purge_packages || warning "Failed to purge dummy deb ($package_name)"
       fi
     fi
+    unset package_name
 
     echo -e "\n\e[91mFailed to ${mode} ${app}!\e[39m
 \e[40m\e[93m\e[5m◢◣\e[25m\e[39m\e[49m\e[93mNeed help? Copy the \e[1mENTIRE\e[0m\e[49m\e[93m terminal output or take a screenshot.

--- a/manage
+++ b/manage
@@ -277,7 +277,7 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
   else #if app failed to install/uninstall
 
     #remove dummy deb if app failed to install (to avoid dummy debs being left on a users install for broken apps)
-    if [[ ${mode} == "install" ]]; then
+    if [[ ${mode} == "install" ]] && [[ "$(app_type "$app")" == standard ]]; then
       local package_name="$(app_to_pkgname "$app")"
       local output="$(sudo -E apt purge -y $package_name 2>&1 | less_apt | tee /dev/stderr)"
       if [ $? != 0 ];then

--- a/manage
+++ b/manage
@@ -275,6 +275,17 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
     mv "$logfile" "$(echo "$logfile" | sed 's+-incomplete-+-success-+g')" #rename logfile to indicate it was successful
     
   else #if app failed to install/uninstall
+
+    #remove dummy deb if app failed to install (to avoid dummy debs being left on a users install for broken apps)
+    if [[ ${mode} == "install" ]]; then
+      local package_name="$(app_to_pkgname "$app")"
+      local output="$(sudo -E apt purge -y $package_name 2>&1 | less_apt | tee /dev/stderr)"
+      if [ $? != 0 ];then
+        echo "$output"
+        warning "Failed to purge dummy deb ($package_name)"
+      fi
+    fi
+
     echo -e "\n\e[91mFailed to ${mode} ${app}!\e[39m
 \e[40m\e[93m\e[5m◢◣\e[25m\e[39m\e[49m\e[93mNeed help? Copy the \e[1mENTIRE\e[0m\e[49m\e[93m terminal output or take a screenshot.
 Please ask on Github: \e[94m\e[4mhttps://github.com/Botspot/pi-apps/issues/new/choose\e[24m\e[93m


### PR DESCRIPTION
- Removed the unnecessary dummy deb package purge if install_packages is run multiple times in a script
- moved dummy deb package purge to occur if the entire app install script fails (that way dummy debs for a "corrupted" install do not remain on the users OS)

these changes now allow for script writers to implement `install_packages` in their script and allow for it to fail non-fatally and keep the previous Depends: packages

for example: its nice to have adoptopenjdk-16 but not necessary for MultiMC to work, so install_packages for this specific package is made non-fatal, but without the changes here, ALL other previously installed dependencies are removed from the dummy deb since it is purged

for scripts where failing `install_packages` is a fatal error, there is no change as the dummy deb gets purged by the manage script now.