### PR TITLE
BUG: imagemagick convert on buster/stretch/bionic

### DIFF
--- a/api
+++ b/api
@@ -74,7 +74,7 @@ generate_splashscreen() { #Place 10 random app icons on the loading screen for t
   s_IMAGE8_$(base64 "${DIRECTORY}/apps/${app9}/icon-64.png" -w 0)_g ; \
   s_IMAGE9_$(base64 "${DIRECTORY}/apps/${app10}/icon-64.png" -w 0)_g" "${DIRECTORY}/icons/vector/splashscreen-original.svg" > "${DIRECTORY}/icons/vector/splashscreen.svg"
   
-  convert +antialias "${DIRECTORY}/icons/vector/splashscreen.svg" "${DIRECTORY}/icons/splashscreen.png"
+  rsvg-convert "${DIRECTORY}/icons/vector/splashscreen.svg" > "${DIRECTORY}/icons/splashscreen.png"
   
 }
 #end of output functions

--- a/gui
+++ b/gui
@@ -139,6 +139,12 @@ runonce <<"EOF"
   if ! command -v convert >/dev/null ;then
     sudo apt install -y --no-install-recommends imagemagick
   fi
+
+  # ensure rsvg2-bin is installed
+
+  if ! command -v rsvg-convert >/dev/null ;then
+    sudo apt install -y --no-install-recommends librsvg2-bin
+  fi
   
   # ensure bc is installed
   if ! command -v bc >/dev/null ;then

--- a/install
+++ b/install
@@ -23,7 +23,7 @@ fi
 sudo apt update || error "The command 'sudo apt update' failed. Before Pi-Apps will work, you must fix your apt package-management system."
 
 #install dependencies
-dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc'
+dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick librsvg2-bin bc'
 ## Install dependencies if necessary
 if ! dpkg -s $dependencies >/dev/null 2>&1; then
   sudo apt install $dependencies -y -f --no-install-recommends


### PR DESCRIPTION
addresses issue raised on discord about bug in older versions of imagemagick convert function where png is corrupted and unusable (see below). librsvg2-bin is less than 50KB in size so its not taking up any measurable space

edit: this works on ubuntu bionic but seems to hang on raspbian buster, see below

![Screenshot_from_2022-01-01_23-31-54](https://user-images.githubusercontent.com/28281419/147867278-bbf7a53e-1d0e-4aa4-9c77-4ad891e0f2f4.png)

