### PR TITLE
Use `rsvg-convert` to convert SVG to PNG

### DIFF
--- a/api
+++ b/api
@@ -74,7 +74,7 @@ generate_splashscreen() { #Place 10 random app icons on the loading screen for t
   s_IMAGE8_$(base64 "${DIRECTORY}/apps/${app9}/icon-64.png" -w 0)_g ; \
   s_IMAGE9_$(base64 "${DIRECTORY}/apps/${app10}/icon-64.png" -w 0)_g" "${DIRECTORY}/icons/vector/splashscreen-original.svg" > "${DIRECTORY}/icons/vector/splashscreen.svg"
   
-  convert +antialias "${DIRECTORY}/icons/vector/splashscreen.svg" "${DIRECTORY}/icons/splashscreen.png"
+  rsvg-convert  "${DIRECTORY}/icons/vector/splashscreen.svg" > "${DIRECTORY}/icons/splashscreen.png"
   
 }
 #end of output functions


### PR DESCRIPTION
Since `yad` supports SVG image, we can simply show SVG splashscreen, without convert it into PNG.