### PR TITLE
add splashscreen icons to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ update
 etc/genapplist-yad
 data
 logs
+icons/vector/splashscreen.svg
+icons/splashscreen.png


### PR DESCRIPTION
these files are generated by pi-apps and do not exist in the git repo