### PR TITLE
Use ASCII version of `Pi-Apps` text in `generate_logo`

### DIFF
--- a/api
+++ b/api
@@ -32,20 +32,17 @@ status_green() { #announce the success of a major action
 generate_logo() { #display colorized Pi-Apps logo in terminal
   #generate pi-apps logo
   #https://misc.flogisoft.com/bash/tip_colors_and_formatting
-  blue_text='\e[38;5;21m' #blue='\e[38;5;27m' #lighter
-  green_text='\e[38;5;46m'
-  darkgreen_text='\e[38;5;34m'
-  red_text='\e[38;5;197m'
-  white_text='\e[97m'
-  default_background='\e[49m'
-  white_background='\e[107m'
-  black_background='\e[40m'
-  echo -e "${black_background}${white_text}    ${green_text}🭊${darkgreen_text}▅▅▅▅${green_text}🬿${black_background}${white_text}
- ${blue_text}🭈▂▂${green_text}█${blue_text}▂▂▂▂${green_text}█${blue_text}▂▂🬽${black_background}${white_text}                    
- ${white_background}${blue_text}▌  ${red_text}${black_background}▗▖▗▖▗▖${white_background}${blue_text}  ▐${black_background}${white_text}   █▀█ █ ▄▄ ▄▀█ █▀█ █▀█ █▀
- ${white_background}${blue_text}▌  ${red_text}${black_background}▗▖▗▖▗▖${white_background}${blue_text}  ▐${black_background}${white_text}   █▀▀ █    █▀█ █▀▀ █▀▀ ▄█
- ${white_background}${blue_text}▌  ${red_text}${black_background}▗▖▗▖▗▖${white_background}${blue_text}  ▐${black_background}${white_text}
- ${blue_text}🭓${white_background}🬭🬭🬰🬰🬰🬰🬰🬰🬭🬭${black_background}🭞${default_background} ${black_background}${white_text}\e[0m\n" 
+  blue='\e[38;5;21m' #blue='\e[38;5;27m' #lighter
+  green='\e[38;5;46m'
+  darkgreen='\e[38;5;34m'
+  red='\e[38;5;197m'
+  echo -e "\e[40m\e[97m    ${green}🭊${darkgreen}▅▅▅▅${green}🬿\e[40m\e[97m
+ ${blue}🭈▂▂${green}█${blue}▂▂▂▂${green}█${blue}▂▂🬽\e[40m\e[97m
+ \e[107m${blue}▌  ${red}\e[40m▗▖▗▖▗▖\e[107m${blue}  ▐\e[40m\e[97m   █▀▀🭍 ▄
+ \e[107m${blue}▌  ${red}\e[40m▗▖▗▖▗▖\e[107m${blue}  ▐\e[40m\e[97m   █▄▄🭞 ▄ ${blue}▄▄\e[97m 🭂▀▀█ █▀▀🭍 █▀▀🭍 🭂🬰🬰🬰
+ \e[107m${blue}▌  ${red}\e[40m▗▖▗▖▗▖\e[107m${blue}  ▐\e[40m\e[97m   █    █    🭓▄▄█ █▄▄🭞 █▄▄🭞 ▄▄▄🭞
+ ${blue}🭓\e[107m🬭🬭🬰🬰🬰🬰🬰🬰🬭🬭\e[40m🭞\e[40m\e[97m                  █    █
+\e[0m\e[0m"
 }
 
 generate_splashscreen() { #Place 10 random app icons on the loading screen for the next time Pi-Apps launches

--- a/api
+++ b/api
@@ -32,17 +32,22 @@ status_green() { #announce the success of a major action
 generate_logo() { #display colorized Pi-Apps logo in terminal
   #generate pi-apps logo
   #https://misc.flogisoft.com/bash/tip_colors_and_formatting
-  blue='\e[38;5;21m' #blue='\e[38;5;27m' #lighter
-  green='\e[38;5;46m'
-  darkgreen='\e[38;5;34m'
-  red='\e[38;5;197m'
-  echo -e "\e[40m\e[97m    ${green}🭊${darkgreen}▅▅▅▅${green}🬿\e[40m\e[97m
- ${blue}🭈▂▂${green}█${blue}▂▂▂▂${green}█${blue}▂▂🬽\e[40m\e[97m
- \e[107m${blue}▌  ${red}\e[40m▗▖▗▖▗▖\e[107m${blue}  ▐\e[40m\e[97m  ▕ᑐ • ▁  ʌ
- \e[107m${blue}▌  ${red}\e[40m▗▖▗▖▗▖\e[107m${blue}  ▐\e[40m\e[97m  ▕  │   ╱‾╲▕ᑐ ▕ᑐ Ｓ
- \e[107m${blue}▌  ${red}\e[40m▗▖▗▖▗▖\e[107m${blue}  ▐\e[40m\e[97m            ▕  ▕
- ${blue}🭓\e[107m🬭🬭🬰🬰🬰🬰🬰🬰🬭🬭\e[40m🭞\e[49m
-\e[0m\e[0m"
+  blue_text='\e[38;5;21m' #blue='\e[38;5;27m' #lighter
+  green_text='\e[38;5;46m'
+  darkgreen_text='\e[38;5;34m'
+  red_text='\e[38;5;197m'
+  white_text='\e[97m'
+  default_background='\e[49m'
+  white_background='\e[107m'
+  black_background='\e[40m'
+  echo -e "${black_background}${white_text}    ${green_text}🭊${darkgreen_text}▅▅▅▅${green_text}🬿${black_background}${white_text}      _____ _                               
+ ${blue_text}🭈▂▂${green_text}█${blue_text}▂▂▂▂${green_text}█${blue_text}▂▂🬽${black_background}${white_text}  |  __ (_)        /\                    
+ ${white_background}${blue_text}▌  ${red_text}${black_background}▗▖▗▖▗▖${white_background}${blue_text}  ▐${black_background}${white_text}  | |__) | ______ /  \   _ __  _ __  ___ 
+ ${white_background}${blue_text}▌  ${red_text}${black_background}▗▖▗▖▗▖${white_background}${blue_text}  ▐${black_background}${white_text}  |  ___/ |______/ /\ \ | '_ \| '_ \/ __|
+ ${white_background}${blue_text}▌  ${red_text}${black_background}▗▖▗▖▗▖${white_background}${blue_text}  ▐${black_background}${white_text}  | |   | |     / ____ \| |_) | |_) \__ \
+ \n ${blue_text}🭓${white_background}🬭🬭🬰🬰🬰🬰🬰🬰🬭🬭${black_background}🭞${default_background} ${black_background}${white_text} |_|   |_|    /_/    \_\ .__/| .__/|___/
+                                     | |   | |        
+                                     |_|   |_|        \e[0m\n" 
 }
 
 generate_splashscreen() { #Place 10 random app icons on the loading screen for the next time Pi-Apps launches

--- a/api
+++ b/api
@@ -40,14 +40,12 @@ generate_logo() { #display colorized Pi-Apps logo in terminal
   default_background='\e[49m'
   white_background='\e[107m'
   black_background='\e[40m'
-  echo -e "${black_background}${white_text}    ${green_text}🭊${darkgreen_text}▅▅▅▅${green_text}🬿${black_background}${white_text}      _____ _                               
- ${blue_text}🭈▂▂${green_text}█${blue_text}▂▂▂▂${green_text}█${blue_text}▂▂🬽${black_background}${white_text}  |  __ (_)        /\                    
- ${white_background}${blue_text}▌  ${red_text}${black_background}▗▖▗▖▗▖${white_background}${blue_text}  ▐${black_background}${white_text}  | |__) | ______ /  \   _ __  _ __  ___ 
- ${white_background}${blue_text}▌  ${red_text}${black_background}▗▖▗▖▗▖${white_background}${blue_text}  ▐${black_background}${white_text}  |  ___/ |______/ /\ \ | '_ \| '_ \/ __|
- ${white_background}${blue_text}▌  ${red_text}${black_background}▗▖▗▖▗▖${white_background}${blue_text}  ▐${black_background}${white_text}  | |   | |     / ____ \| |_) | |_) \__ \
- \n ${blue_text}🭓${white_background}🬭🬭🬰🬰🬰🬰🬰🬰🬭🬭${black_background}🭞${default_background} ${black_background}${white_text} |_|   |_|    /_/    \_\ .__/| .__/|___/
-                                     | |   | |        
-                                     |_|   |_|        \e[0m\n" 
+  echo -e "${black_background}${white_text}    ${green_text}🭊${darkgreen_text}▅▅▅▅${green_text}🬿${black_background}${white_text}
+ ${blue_text}🭈▂▂${green_text}█${blue_text}▂▂▂▂${green_text}█${blue_text}▂▂🬽${black_background}${white_text}                    
+ ${white_background}${blue_text}▌  ${red_text}${black_background}▗▖▗▖▗▖${white_background}${blue_text}  ▐${black_background}${white_text}   █▀█ █ ▄▄ ▄▀█ █▀█ █▀█ █▀
+ ${white_background}${blue_text}▌  ${red_text}${black_background}▗▖▗▖▗▖${white_background}${blue_text}  ▐${black_background}${white_text}   █▀▀ █    █▀█ █▀▀ █▀▀ ▄█
+ ${white_background}${blue_text}▌  ${red_text}${black_background}▗▖▗▖▗▖${white_background}${blue_text}  ▐${black_background}${white_text}
+ ${blue_text}🭓${white_background}🬭🬭🬰🬰🬰🬰🬰🬰🬭🬭${black_background}🭞${default_background} ${black_background}${white_text}\e[0m\n" 
 }
 
 generate_splashscreen() { #Place 10 random app icons on the loading screen for the next time Pi-Apps launches


### PR DESCRIPTION
Result:

![2022-01-05 15-16](https://user-images.githubusercontent.com/88134003/148177137-da9ef16b-7d43-438e-b858-6fa45a0f177d.gif)
