### PR TITLE
Fix `version` variable not detected in Angry IP Scanner install script

### DIFF
--- a/apps/Angry IP scanner/install
+++ b/apps/Angry IP scanner/install
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 version=3.7.6
-install_packages openjdk-11-jdk rpm fakeroot 'https://github.com/angryip/ipscan/releases/download/${version}/ipscan_${version}_all.deb' || exit 1
+install_packages openjdk-11-jdk rpm fakeroot "https://github.com/angryip/ipscan/releases/download/${version}/ipscan_${version}_all.deb" || exit 1


### PR DESCRIPTION
To fix #1373.