### PR TITLE
Stunt Rally: use 32-bit deb

### DIFF
--- a/apps/Stunt Rally/credits
+++ b/apps/Stunt Rally/credits
@@ -1,2 +1,2 @@
-Compiled and packaged into a deb by Itai-Nelken.
+Compiled and packaged into a deb by Itai-Nelken and ryanfortner.
 Added to pi-apps by Itai-Nelken.

--- a/apps/Stunt Rally/install-32
+++ b/apps/Stunt Rally/install-32
@@ -1,45 +1,7 @@
 #!/bin/bash
 
-install_packages https://archive.org/download/stunt-rally_armhf/stunt-rally_20210305-1_armhf.deb libboost-wave-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libogre-1.9-dev libmygui-dev libsdl2-dev libogg-dev libvorbis-dev libenet-dev libopenal-dev libopenal-dev libbullet-dev libbullet-extras-dev || exit 1
+install_packages https://apt.raspbian-addons.org/debian/pool/main/s/stuntrally/stuntrally_2.6.1-1_armhf.deb || exit 1
 
-#fix menu shortcut icons
-sudo rm /usr/share/applications/stuntrally.desktop &>/dev/null
-sudo rm /usr/share/applications/sr-editor.desktop &>/dev/null
-
-echo "[Desktop Entry]
-Name=Stunt Rally
-GenericName=Racing game
-GenericName[fr]=Jeu de course
-Comment=3D racing game with stunt and rally elements
-Comment[de]=3D-Rennspiel mit Stunt-Elementen
-Comment[fi]=3D Rallipeli stunttielementein
-Comment[fr]=Jeu de course en 3D avec des éléments acrobatiques
-Exec=stuntrally
-Icon=stuntrally
-StartupNotify=false
-Terminal=false
-Type=Application
-Categories=Application;Game;SportsGame;
-" | sudo tee /usr/share/applications/stuntrally.desktop >/dev/null
-
-echo "[Desktop Entry]
-Name=Stunt Rally Track Editor
-Name[fr]=Éditeur de circuits Stunt Rally
-Name[de]=Stunt Rally Streckeneditor
-GenericName=Track editor
-GenericName[de]=Streckeneditor
-GenericName[fr]=Éditeur de circuits
-Comment=Track editor for Stunt Rally
-Comment[de]=Stunt Rally Streckeneditor
-Comment[fi]=Stunt Rally rataeditori
-Comment[fr]=Éditez des circuits pour Stunt Rally
-Exec=sr-editor
-Icon=sr-editor
-StartupNotify=true
-Terminal=false
-Type=Application
-Categories=Application;Game;SportsGame;
-" | sudo tee /usr/share/applications/sr-editor.desktop >/dev/null
 mkdir -p ~/.config/stuntrally
 echo '
 [ car1 ]


### PR DESCRIPTION
This was requested by @Itai-Nelken, and it already includes the desktop entry fixes. I'll open another PR later for a 64-bit deb.