### PR TITLE
fix sonic pi app updater script

### DIFF
--- a/.github/workflows/updates/Sonic Pi.sh
+++ b/.github/workflows/updates/Sonic Pi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 webVer=$(curl -s https://sonic-pi.net | grep -m 1 armhf | sed 's/.*sonic-pi_//g; s/_armhf.*//g')
-armhf_url="https://sonic-pi.net/files/releases/v${version}/sonic-pi_${version}_armhf.deb"
+armhf_url="https://sonic-pi.net/files/releases/v${webVer%_*}/sonic-pi_${webVer}_armhf.deb"
 
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh

--- a/apps/Sonic Pi/install-32
+++ b/apps/Sonic Pi/install-32
@@ -2,5 +2,4 @@
 
 version=3.3.1_1
 
-install_packages https://sonic-pi.net/files/releases/v3.3.1/sonic-pi_${version}_armhf.deb libconfig9 || exit 1
-
+install_packages https://sonic-pi.net/files/releases/v${version%_*}/sonic-pi_${version}_armhf.deb libconfig9 || exit 1


### PR DESCRIPTION
sonic pi uses a non-traditional format for its versions where the _# is not included in the release tag (v#.#.#)