### PR TITLE
Increase Update Script trigger frequency to 5 miniutes

### DIFF
--- a/.github/workflows/update_apps.yml
+++ b/.github/workflows/update_apps.yml
@@ -4,7 +4,7 @@ name: Update_Apps
 on:
   # run at 21:00 UTC every day
   schedule:
-     - cron: '0 21 * * *'
+     - cron: '*/5 * * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Nobody likes late updates. Github Workflows on public repositories can run upto once every 5 minutes for free so why not set it to maximum? Also, although it is set to every 5 minutes, it would run like at most 3 to 5 times every hour.

Note that I use this on multiple repositories of mine like https://github.com/touhidurrr/iplist-youtube