### PR TITLE
Fix MultiMC install for ubuntu derivatives

### DIFF
--- a/apps/Minecraft Java MultiMC5/install
+++ b/apps/Minecraft Java MultiMC5/install
@@ -139,7 +139,7 @@ case "$__os_id" in
                 ;;
             *)
                 requiredver="18.04"
-                if printf '%s\n' "$requiredver" "$DISTRIB_RELEASE" | sort -CV; then
+                if [printf '%s\n' "$requiredver" "$DISTRIB_RELEASE" | sort -CV] || [printf '%s\n' "$requiredver" "$VERSION_ID" | sort -CV]; then
                     status "Skipping OpenJDK PPA, $DISTRIB_CODENAME already has openjdk-16 in the default repositories"
                 else
                     error "$DISTRIB_CODENAME appears to be too old to run/compile MultiMC5"


### PR DESCRIPTION
On elementary OS for RPi, it outputted that it seems to be too old to run/compile MultiMC, but it is based on Ubuntu 20.04.  I patched the version check to include $VERSION_ID, which is what the version ID is under for the upstream release lsb_release file. I have no idea if it is only elementary OS that does it like this, but this should fix it if it is different, and should not affect it if it is not (hopefully, I haven't had a chance to test it yet).