### PR TITLE
improve ubuntu version info check for derivatives in MMC install script

### DIFF
--- a/apps/Minecraft Java MultiMC5/install
+++ b/apps/Minecraft Java MultiMC5/install
@@ -121,9 +121,16 @@ case "$__os_id" in
         install_packages build-essential libopenal1 x11-xserver-utils subversion git clang cmake curl zlib1g-dev openjdk-11-jdk qtbase5-dev || error "Failed to install dependencies"
         ;;
     LinuxMint|Linuxmint|Ubuntu|[Nn]eon|Pop|Zorin|[eE]lementary|[jJ]ing[Oo][sS])
-        # get the $DISTRIB_RELEASE and $DISTRIB_CODENAME first from lsb-release (for ubuntu) and then from the upstream for derivatives
-        source /etc/lsb-release
-        source /etc/upstream-release/lsb-release
+        # get the $DISTRIB_RELEASE and $DISTRIB_CODENAME by calling lsb_release
+        # check if upstream-release is available
+        if [ -f /etc/upstream-release/lsb-release ]; then
+            echo "This is a Ubuntu Derivative, checking the upstream-release version info"
+            DISTRIB_CODENAME=$(lsb_release -uc | awk '{print $2}')
+            DISTRIB_RELEASE=$(lsb_release -ur | awk '{print $2}')
+        else
+            DISTRIB_CODENAME=$(lsb_release -c | awk '{print $2}')
+            DISTRIB_RELEASE=$(lsb_release -r | awk '{print $2}')
+        fi
         case "$DISTRIB_CODENAME" in
             bionic|focal|groovy)
                 ppa_added=$(grep ^ /etc/apt/sources.list /etc/apt/sources.list.d/* | grep -v list.save | grep -v deb-src | grep deb | grep openjdk-r | wc -l)
@@ -173,7 +180,7 @@ cd src || error "Could not move to directory"
 git remote set-url origin https://github.com/MultiMC/Launcher.git
 git checkout --recurse-submodules develop || error "Could not checkout develop branch"
 git pull --recurse-submodules || error "Could Not Pull Latest MultiMC Source Code, verify your ~/MultiMC/src directory hasn't been modified. You can detete the  ~/MultiMC/src folder to attempt to fix this error."
-git checkout --recurse-submodules 63098b6f196cbfdb6b48b013d4dd495f890011ea || error "Could Not Checkout MultiMC Source Code commit, verify your ~/MultiMC/src directory hasn't been modified. You can detete the  ~/MultiMC/src folder to attempt to fix this error."
+git checkout --recurse-submodules 63d4486855723290ebbd4b71632f6e54670e07c6 || error "Could Not Checkout MultiMC Source Code commit, verify your ~/MultiMC/src directory hasn't been modified. You can detete the  ~/MultiMC/src folder to attempt to fix this error."
 # add secrets files
 mkdir -p secrets
 tee secrets/Secrets.h <<'EOF' >>/dev/null


### PR DESCRIPTION
/etc/upstream-release/lsb-release file is not standardized and the variable names differ per distro. lsb_release output, however, is standardized, so switch to it instead
(fixes issue @isteiger noticed)

in theory, this should fix your issue @isteiger