### PR TITLE
add default JVM args to java server and allow user to specify their own

### DIFF
--- a/apps/Minecraft Java Server/install
+++ b/apps/Minecraft Java Server/install
@@ -248,6 +248,19 @@ case "$java_selection" in
     ;;
 esac
 
+jvm_test="1"
+jvm_args=""
+while [[ $jvm_test != 0 ]]; do
+  # userinput jvm_args
+  jvm_args=$(yad --center --wrap --text "Would you like to input any JVM Arguments?\nA defaut list is prepopulated in the text box below.\n\nThe most inportant arguments -XmxXXXXM -XmsXXXXM are at the beginning and define how much ram for your server to use.\nHint, use your keyboard Home key to see the start of this list" --entry --entry-text="-Xmx1200M -Xms1200M -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1" --button="Validate JVM Arguments":0)
+  $java_location $jvm_args -version
+  jvm_test="$?"
+  if [[ $jvm_test != 0 ]]; then
+    echo "Your JVM Arguments were invalid. Your input was: $jvm_args"
+    yad --center --text "OH NO! The JVM Arguments you inputed are either invalid (like a typo) or incompatible with the selected java version.\n\nRefer to the terminal log immeditately above to determine the issue and try again." --button="Try New JVM Arguments":0
+  fi
+done
+
 if [[ "$server_type" == "Forge" ]]; then
   # run the server installer
   rm -f start-server.sh
@@ -270,6 +283,7 @@ if [[ "$server_type" == "Forge" ]]; then
     server_jar=""
     sed -i "s:java:${java_location}:g" run.sh
     sed -i 's:"$@":nogui:g' run.sh
+    echo "$jvm_args" > user_jvm_args.txt
     mv run.sh start-server.sh
     chmod +x start-server.sh
   else
@@ -281,7 +295,7 @@ if [ -n "$server_jar" ]; then
   sh -c "cat > $HOME/Minecraft-Java-Server/start-server.sh << _EOF_
 #!/bin/bash
 echo 'Minecraft Server starting'
-$java_location -jar $HOME/Minecraft-Java-Server/${server_jar} nogui || (echo -e '\e[91mMinecraft Server has crashed or could not start\e[0m'; sleep 10)
+$java_location $jvm_args -jar $HOME/Minecraft-Java-Server/${server_jar} nogui || (echo -e '\e[91mMinecraft Server has crashed or could not start\e[0m'; sleep 10)
 echo 'Minecraft Server has stopped'
 sleep 3
 _EOF_"


### PR DESCRIPTION
JVM (java virtual machine) arguments are used to modify the default parameters used when launching the virtual machine. Such as: changing the allocated ram, changing the default GC (garbage collector timeout), changing the number of threads used for GC, etc. Some are very important for good performance and usability of the server