### PR TITLE
Record failed apps in PR message

### DIFF
--- a/.github/workflows/update_apps.yml
+++ b/.github/workflows/update_apps.yml
@@ -90,7 +90,7 @@ jobs:
           title: "[AUTO] Update App Versions"
           body: |
             Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action.
-            Workflow run: https://github.com/cycool29/pi-apps/actions/runs/${{ github.run_id }}
+            Workflow run: https://github.com/Botspot/pi-apps/actions/runs/${{ github.run_id }}
             Apps updated:
 
             ${{ env.UPDATED_APPS }}

--- a/.github/workflows/update_apps.yml
+++ b/.github/workflows/update_apps.yml
@@ -69,7 +69,15 @@ jobs:
             cat /tmp/updated_apps_sorted >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV
           fi
-
+          
+          if test -f /tmp/failed_apps; then
+            echo "FAILED_APPS<<EOF" >> $GITHUB_ENV
+            cat /tmp/failed_apps | sed '0~1 a\\' >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          fi
+          
+          
+          
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
@@ -81,7 +89,11 @@ jobs:
           branch: "auto-app-updates"
           title: "[AUTO] Update App Versions"
           body: |
-            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action:
+            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action.
+            Workflow run: https://github.com/cycool29/pi-apps/actions/runs/${{ github.run_id }}
             Apps updated:
 
             ${{ env.UPDATED_APPS }}
+
+            ${{ env.FAILED_APPS }}
+            

--- a/.github/workflows/update_github_script.sh
+++ b/.github/workflows/update_github_script.sh
@@ -78,6 +78,7 @@ if [ -n "$pi_apps_ver_32" ]  && [ -a "$DIRECTORY/apps/$app_name/install-32" ]; t
             echo "$app_name-armhf " >> /tmp/updated_apps
         else
             warning "Updating $app_name install-32 had been skipped, the upstream file $armhf_url does NOT exist."
+            echo "Updating $app_name install-32 had been skipped, the upstream file $armhf_url does NOT exist." >> /tmp/failed_apps
         fi
     fi
 fi
@@ -95,6 +96,7 @@ if [ -n "$pi_apps_ver_64" ] && [ -a "$DIRECTORY/apps/$app_name/install-64" ]; th
             echo "$app_name-arm64 " >> /tmp/updated_apps
         else
             warning "Updating $app_name install-64 had been skipped, the upstream file $arm64_url does NOT exist."
+            echo "Updating $app_name install-64 had been skipped, the upstream file $arm64_url does NOT exist." >> /tmp/failed_apps
         fi
     fi
 fi
@@ -112,6 +114,7 @@ if [ -n "$pi_apps_ver" ] && [ -n "$all_url" ] && [ -a "$DIRECTORY/apps/$app_name
             echo "$app_name-all " >> /tmp/updated_apps
         else
             warning "Updating $app_name install had been skipped, the upstream file $all_url does NOT exist."
+            echo "Updating $app_name install had been skipped, the upstream file $all_url does NOT exist." >> /tmp/failed_apps
         fi
     fi
 fi
@@ -129,6 +132,7 @@ if [ -n "$pi_apps_ver" ] && [ -n "$armhf_url" ] && [ -n "$arm64_url" ] && [ -a "
             echo "$app_name-all " >> /tmp/updated_apps
         else
             warning "Updating $app_name install had been skipped, the upstream file $armhf_url or $arm64_url does NOT exist."
+            echo "Updating $app_name install had been skipped, the upstream file $armhf_url or $arm64_url does NOT exist." >> /tmp/failed_apps
         fi
     fi
 fi
@@ -136,7 +140,8 @@ fi
 done
 else
 
-warning "webVer variable is missing for $appname update script, please fix this script, skipping update check"
+warning "webVer variable is missing for $app_name update script, please fix this script, skipping update check."
+echo "webVer variable is missing for $app_name update script, please fix this script, skipping update check." >> /tmp/failed_apps
 
 fi
 


### PR DESCRIPTION
If an app failed to update, we won't know about that unless we check the workflow run. So I record the failed apps into `/tmp/failed_apps`, like how updated apps have been recorded, and print them with the workflow run URL in PR message. 

Here is a live example: https://github.com/cycool29/pi-apps/pull/4