### PR TITLE
Include Flameshot in apps to hide for TwisterOS

### DIFF
--- a/install
+++ b/install
@@ -118,7 +118,8 @@ Windows 10 Theme
 Chromium Widevine
 Lightpad
 Wine (x86)
-Mac OS Theme"
+Mac OS Theme
+Flameshot"
   PREIFS="$IFS"
   IFS=$'\n'
   for app in $apps ;do


### PR DESCRIPTION
Flameshot is not included in the apps to hide for TwisterOS even though it is already installed on Twister.