### PR TITLE
Revert "Include Flameshot in apps to hide for TwisterOS"

### DIFF
--- a/install
+++ b/install
@@ -118,8 +118,7 @@ Windows 10 Theme
 Chromium Widevine
 Lightpad
 Wine (x86)
-Mac OS Theme
-Flameshot"
+Mac OS Theme"
   PREIFS="$IFS"
   IFS=$'\n'
   for app in $apps ;do


### PR DESCRIPTION
Reverts Botspot/pi-apps#1528 because of @Itai-Nelken's comment on how the version of FlameShot included in TwisterOS is much older than what's available in Pi-Apps.