### PR TITLE
snapdrop: update Electron version, use debs

### DIFF
--- a/apps/Snapdrop/credits
+++ b/apps/Snapdrop/credits
@@ -1,1 +1,1 @@
-Added by @ryanfortner (Github)
+Packaged and added by Ryan Fortner

--- a/apps/Snapdrop/install-32
+++ b/apps/Snapdrop/install-32
@@ -1,18 +1,3 @@
 #!/bin/bash
-rm -f Snapdrop-linux-armv7l.zip
 
-wget https://github.com/ryanfortner/snapdrop-rpi/raw/master/Snapdrop-linux-armv7l.zip || error "Failed to download archive!"
-unzip Snapdrop-linux-armv7l.zip || error "Failed to extract archive!"
-rm -f Snapdrop-linux-armv7l.zip
-
-# Desktop entry
-echo "[Desktop Entry]
-Name=Snapdrop
-GenericName=Local File Sharing
-Comment=Snapdrop: local file sharing in your browser. Inspired by Apple's Airdrop.
-Exec=$HOME/snapdrop/Snapdrop
-Icon=$(dirname "$0")/icon-64.png
-Terminal=true
-StartupNotify=true
-Categories=Network;
-Type=Application" > ~/.local/share/applications/snapdrop.desktop || error "Failed to create desktop shortcut!"
+install_packages "https://apt.raspbian-addons.org/debian/pool/main/s/snapdrop/snapdrop_20220226_armhf.deb"

--- a/apps/Snapdrop/install-64
+++ b/apps/Snapdrop/install-64
@@ -1,18 +1,3 @@
 #!/bin/bash
-rm -f Snapdrop-linux-arm64.zip
 
-wget https://github.com/ryanfortner/snapdrop-rpi/raw/master/Snapdrop-linux-arm64.zip || error "Failed to download archive!"
-unzip Snapdrop-linux-arm64.zip || error "Failed to extract archive!"
-rm -f Snapdrop-linux-arm64.zip || error "Failed to remove archive!"
-
-# Desktop entry
-echo "[Desktop Entry]
-Name=Snapdrop
-GenericName=Local File Sharing
-Comment=Snapdrop: local file sharing in your browser. Inspired by Apple's Airdrop.
-Exec=$HOME/snapdrop/Snapdrop
-Icon=$(dirname "$0")/icon-64.png
-Terminal=true
-StartupNotify=true
-Categories=Network;
-Type=Application" > ~/.local/share/applications/snapdrop.desktop || error "Failed to create desktop shortcut!"
+install_packages "https://apt.raspbian-addons.org/debian/pool/main/s/snapdrop/snapdrop_20220226_arm64.deb"

--- a/apps/Snapdrop/uninstall
+++ b/apps/Snapdrop/uninstall
@@ -1,3 +1,3 @@
 #!/bin/bash
-rm -rf ~/snapdrop || error "Failed to remove install directory!"
-rm -f ~/.local/share/applications/snapdrop.desktop
+
+purge_packages || exit 1


### PR DESCRIPTION
- uses debs to install Snapdrop for easier install/uninstall
- updated electron version, so the app actually works