### PR TITLE
Use `$(dirname "${file}")` as argument of `-d` in aria2c flags

### DIFF
--- a/api
+++ b/api
@@ -1945,7 +1945,7 @@ wget() { #Intercept all wget commands. When possible, uses aria2c.
     
     #use these flags for aria2c
     aria2_flags=(-c -x 16 -s 16 --max-tries=10 --retry-wait=30 --max-file-not-found=5 --http-no-cache=true --check-certificate=false --allow-overwrite=true --auto-file-renaming=false \
-      --console-log-level=error --show-console-readout=false --summary-interval=1 "$url" --dir '/' -o "${file:1}")
+      --console-log-level=error --show-console-readout=false --summary-interval=1 "$url" -d "$(dirname "${file}")" -o "$(basename "${file}")")
     
     #suppress output if -q flag passed
     if [ "$quiet" == 1 ];then


### PR DESCRIPTION
To fix `Permission Denied` error in aria2c.