### PR TITLE
use logo image on readme as website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<p align="center">
-    <img src="https://github.com/Botspot/pi-apps/blob/master/icons/proglogo.png?raw=true" href="https://pi-apps.io" alt="Pi-Apps logo">
+<p align="center" href="https://pi-apps.io">
+    <img src="https://github.com/Botspot/pi-apps/blob/master/icons/proglogo.png?raw=true" alt="Pi-Apps logo">
 </p>
 <p align="center">The most popular app store for Raspberry Pi computers. 100% free, open-source and written in shell scripts.
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://github.com/Botspot/pi-apps/blob/master/icons/proglogo.png?raw=true" alt="Pi-Apps logo">
+    <img src="https://github.com/Botspot/pi-apps/blob/master/icons/proglogo.png?raw=true" href="https://pi-apps.io" alt="Pi-Apps logo">
 </p>
 <p align="center">The most popular app store for Raspberry Pi computers. 100% free, open-source and written in shell scripts.
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-<p align="center" href="https://pi-apps.io">
-    <img src="https://github.com/Botspot/pi-apps/blob/master/icons/proglogo.png?raw=true" alt="Pi-Apps logo">
+<p align="center">
+    <a href="https://pi-apps.io">
+        <img src="https://github.com/Botspot/pi-apps/blob/master/icons/proglogo.png?raw=true" alt="Pi-Apps logo">
+    </a>
 </p>
 <p align="center">The most popular app store for Raspberry Pi computers. 100% free, open-source and written in shell scripts.
 <p align="center">


### PR DESCRIPTION
When you click on the logo on the readme, a new tab will open with the pi-apps.io website.