### PR TITLE
cura: remove xcbutil linking

### DIFF
--- a/apps/Cura/install-32
+++ b/apps/Cura/install-32
@@ -13,7 +13,7 @@ install_packages libfuse2 libgles-dev || exit 1
 (install_packages "https://github.com/unlimitedbacon/stl-thumb/releases/download/v${version2}/stl-thumb_${version2}_armhf.deb") || warning "Failed to install stl-thumb package, but continuing as it's not crucial to Cura's operation."
 
 #link libxcb-util.so.0 to solve "error while loading shared libraries: libxcb-util.so.0: cannot open shared object file: No such file or directory"
-sudo ln -s /usr/lib/arm-linux-gnueabihf/libxcb-util.so.1.0.0 /usr/lib/arm-linux-gnueabihf/libxcb-util.so.0 2>/dev/null
+#sudo ln -s /usr/lib/arm-linux-gnueabihf/libxcb-util.so.1.0.0 /usr/lib/arm-linux-gnueabihf/libxcb-util.so.0 2>/dev/null
 
 if [ -z "$(cat ~/.config/mimeapps.list | grep -F 'cura.desktop')" ];then
   echo "Associating the STL mimetype for Cura..."

--- a/apps/Cura/install-32
+++ b/apps/Cura/install-32
@@ -12,9 +12,6 @@ install_packages libfuse2 libgles-dev || exit 1
 #get stl-thumb package - non-fatal as it's not crucial to Cura's function
 (install_packages "https://github.com/unlimitedbacon/stl-thumb/releases/download/v${version2}/stl-thumb_${version2}_armhf.deb") || warning "Failed to install stl-thumb package, but continuing as it's not crucial to Cura's operation."
 
-#link libxcb-util.so.0 to solve "error while loading shared libraries: libxcb-util.so.0: cannot open shared object file: No such file or directory"
-#sudo ln -s /usr/lib/arm-linux-gnueabihf/libxcb-util.so.1.0.0 /usr/lib/arm-linux-gnueabihf/libxcb-util.so.0 2>/dev/null
-
 if [ -z "$(cat ~/.config/mimeapps.list | grep -F 'cura.desktop')" ];then
   echo "Associating the STL mimetype for Cura..."
   echo "[Added Associations]


### PR DESCRIPTION
With the latest build of Cura this line is not required.