### PR TITLE
Fix Hyper update script

### DIFF
--- a/.github/workflows/updates/Hyper.sh
+++ b/.github/workflows/updates/Hyper.sh
@@ -7,6 +7,6 @@ source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh
 
 unset webVer
 unset armhf_url
-
+webVer=$(get_release vercel/hyper)
 arm64_url="https://github.com/vercel/hyper/releases/download/v${version}/hyper_${version}_arm64.deb"
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh

--- a/.github/workflows/updates/Hyper.sh
+++ b/.github/workflows/updates/Hyper.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 
 webVer=$(get_release Jai-JAP/hyper-arm-builds)
-armhf_url="https://github.com/Jai-JAP/hyper-arm-builds/releases/download/v${version}/hyper_${version}_armv7l.deb"
+armhf_url="https://github.com/Jai-JAP/hyper-arm-builds/releases/download/v${webVer}hyper_${webVer}_armv7l.deb"
+arm64_url="https://github.com/Jai-JAP/hyper-arm-builds/releases/download/v${version}/hyper_${version}_arm64.deb"
 
-source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh
-
-unset webVer
-unset armhf_url
-webVer=$(get_release vercel/hyper)
-arm64_url="https://github.com/vercel/hyper/releases/download/v${version}/hyper_${version}_arm64.deb"
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh

--- a/.github/workflows/updates/Hyper.sh
+++ b/.github/workflows/updates/Hyper.sh
@@ -2,6 +2,6 @@
 
 webVer=$(get_release Jai-JAP/hyper-arm-builds)
 armhf_url="https://github.com/Jai-JAP/hyper-arm-builds/releases/download/v${webVer}hyper_${webVer}_armv7l.deb"
-arm64_url="https://github.com/Jai-JAP/hyper-arm-builds/releases/download/v${version}/hyper_${version}_arm64.deb"
+arm64_url="https://github.com/Jai-JAP/hyper-arm-builds/releases/download/v${webVer}/hyper_${webVer}_arm64.deb"
 
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh

--- a/.github/workflows/updates/Hyper.sh
+++ b/.github/workflows/updates/Hyper.sh
@@ -2,6 +2,11 @@
 
 webVer=$(get_release Jai-JAP/hyper-arm-builds)
 armhf_url="https://github.com/Jai-JAP/hyper-arm-builds/releases/download/v${version}/hyper_${version}_armv7l.deb"
-arm64_url="https://github.com/Jai-JAP/hyper-arm-builds/releases/download/v${version}/hyper_${version}_arm64.deb"
 
+source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh
+
+unset webVer
+unset armhf_url
+
+arm64_url="https://github.com/vercel/hyper/releases/download/v${version}/hyper_${version}_arm64.deb"
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh

--- a/apps/Hyper/install-64
+++ b/apps/Hyper/install-64
@@ -2,7 +2,7 @@
 
 version=3.2.3
 
-install_packages https://github.com/vercel/hyper/releases/download/v${version}/hyper_${version}_arm64.deb || exit 1
+install_packages https://github.com/Jai-JAP/hyper-arm-builds/releases/download/v${version}/hyper_${version}_arm64.deb || exit 1
 
 status "Moving Menu entry to Accessories..."
 sudo sed -i 's/Categories=TerminalEmulator;/Categories=Utility;/' /usr/share/applications/hyper.desktop || error "Failed to fix desktop file!"

--- a/apps/Hyper/install-64
+++ b/apps/Hyper/install-64
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-version=3.2.0
+version=3.2.3
 
-install_packages https://github.com/Jai-JAP/hyper-arm-builds/releases/download/v${version}/hyper_${version}_arm64.deb || exit 1
+install_packages https://github.com/vercel/hyper/releases/download/v${version}/hyper_${version}_arm64.deb || exit 1
 
 status "Moving Menu entry to Accessories..."
 sudo sed -i 's/Categories=TerminalEmulator;/Categories=Utility;/' /usr/share/applications/hyper.desktop || error "Failed to fix desktop file!"


### PR DESCRIPTION
Hyper has official arm64 debs, I haven't tested this (I don't use arm64), so somebody should probably test the official debs, but if the official debs work, then @Jai-JAP only has to build armhf debs.

I also bumped the version on install-64 to `3.2.3`, the latest release.