### PR TITLE
fix Sublime Text arm64 installation script

### DIFF
--- a/apps/Sublime Text/description
+++ b/apps/Sublime Text/description
@@ -3,4 +3,5 @@ It natively supports many programming languages and markup languages. Additional
 
 To run: Menu -> Programming -> Sublime Text
 
-This runs Sublime Text v2 with the Box86 emulator.
+On armhf based Operating Systems, this runs Sublime Text 2 with the Box86 emulator.
+However on arm64 based Operating Systems this runs the latest Sublime Text 4 without any emulation.

--- a/apps/Sublime Text/install-64
+++ b/apps/Sublime Text/install-64
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ## Install dependencies
-install_packages wget gpg || error "Failed to install dependencies"
+install_packages wget || error "Failed to install dependencies"
 
 status "Adding GPG key..."
 wget -qO- https://download.sublimetext.com/sublimehq-pub.gpg | sudo tee /etc/apt/trusted.gpg.d/sublimehq.asc || error "Failed to add GPG key for sublime-text repository!"

--- a/apps/Sublime Text/install-64
+++ b/apps/Sublime Text/install-64
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-## Install dependencies
-install_packages wget || error "Failed to install dependencies"
-
 status "Adding GPG key..."
 wget -qO- https://download.sublimetext.com/sublimehq-pub.gpg | sudo tee /etc/apt/trusted.gpg.d/sublimehq.asc || error "Failed to add GPG key for sublime-text repository!"
 echo "deb https://download.sublimetext.com/ apt/stable/" | sudo tee /etc/apt/sources.list.d/sublime-text.list

--- a/apps/Sublime Text/install-64
+++ b/apps/Sublime Text/install-64
@@ -1,6 +1,10 @@
 #!/bin/bash
-echo "Adding GPG key..."
-wget -qO- https://download.sublimetext.com/sublimehq-pub.gpg | sudo apt-key add - || error "Failed to add GPG key for sublime-text repository!"
+
+## Install dependencies
+install_packages wget gpg || error "Failed to install dependencies"
+
+status "Adding GPG key..."
+gpg --keyserver keyserver.ubuntu.com --recv-keys F57D4F59BD3DF454 || error "Failed to add GPG key for sublime-text repository!"
 echo "deb https://download.sublimetext.com/ apt/stable/" | sudo tee /etc/apt/sources.list.d/sublime-text.list
 
 (install_packages sublime-text)

--- a/apps/Sublime Text/install-64
+++ b/apps/Sublime Text/install-64
@@ -4,7 +4,7 @@
 install_packages wget gpg || error "Failed to install dependencies"
 
 status "Adding GPG key..."
-gpg --import <(wget -qO- https://download.sublimetext.com/sublimehq-pub.gpg) || error "Failed to add GPG key for sublime-text repository!"
+wget -qO- https://download.sublimetext.com/sublimehq-pub.gpg | sudo tee /etc/apt/trusted.gpg.d/sublimehq.asc || error "Failed to add GPG key for sublime-text repository!"
 echo "deb https://download.sublimetext.com/ apt/stable/" | sudo tee /etc/apt/sources.list.d/sublime-text.list
 
 (install_packages sublime-text)

--- a/apps/Sublime Text/install-64
+++ b/apps/Sublime Text/install-64
@@ -4,7 +4,7 @@
 install_packages wget gpg || error "Failed to install dependencies"
 
 status "Adding GPG key..."
-gpg --keyserver keyserver.ubuntu.com --recv-keys F57D4F59BD3DF454 || error "Failed to add GPG key for sublime-text repository!"
+gpg --import <(wget -qO- https://download.sublimetext.com/sublimehq-pub.gpg) || error "Failed to add GPG key for sublime-text repository!"
 echo "deb https://download.sublimetext.com/ apt/stable/" | sudo tee /etc/apt/sources.list.d/sublime-text.list
 
 (install_packages sublime-text)

--- a/apps/Sublime Text/uninstall
+++ b/apps/Sublime Text/uninstall
@@ -3,3 +3,4 @@
 rm -f ~/.local/share/applications/sublime-text.desktop
 rm -rf ~/"Sublime Text 2"
 purge_packages || exit 1
+remove_repofile_if_unused /etc/apt/sources.list.d/sublime-text.list


### PR DESCRIPTION
As we know that `apt-key` is deprecated, it doesn't work on Raspberry Pi OS arm64.
The changes I made was manually tested by me so I can tell that they work.
Installing the package `gpg` is not required as it already comes default with a fresh installation of Raspberry Pi OS arm64, I tried to install it anyways for better support.