### PR TITLE
Change Notepad++ update script to fetch version from official website

### DIFF
--- a/.github/workflows/updates/Notepad ++.sh
+++ b/.github/workflows/updates/Notepad ++.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-webVer=$(get_release notepad-plus-plus/notepad-plus-plus)
+webVer=$(wget -qO- https://notepad-plus-plus.org/ | grep 'Current Version' | sed 's/.*Current Version //g' | sed 's+<.*++g')
 armhf_url="https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v${webVer}/npp.${webVer}.portable.zip"
 
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh


### PR DESCRIPTION
Since sometimes the devs messed up with their GitHub release, the version from its [official website](https://notepad-plus-plus.org) is more stable for version checking.