### PR TITLE
add and update categories

### DIFF
--- a/etc/categories
+++ b/etc/categories
@@ -1,97 +1,97 @@
-Alacritty Terminal|Tools
-All Is Well|Tools
+Alacritty Terminal|Terminals
+All Is Well|System Management
 Amiberry|Games
 AndroidBuddy|Tools
 Angry IP scanner|Internet
 AntiMicroX|Tools
 AnyDesk|Internet
-Arduino|Editors
+Arduino|Programming
 AstroMenace|Games
 Audacious|Multimedia
 Audacity|Multimedia
-Autostar|Tools
+Autostar|System Management
 BalenaEtcher|Tools
-BleachBit|Tools
-BlockBench|Editors
-BlockPi|Editors
-BlueJ Java IDE|Editors
+BleachBit|System Management
+BlockBench|Creative Arts
+BlockPi|Programming
+BlueJ Java IDE|Programming
 Bongo Cam|Multimedia
-Box64|Tools
-Box86|Tools
-Boxy SVG|Editors
+Box64|Tools/Emulation
+Box86|Tools/Emulation
+Boxy SVG|Creative Arts
 Browsh|Internet/Browsers
-btop++|Tools
+btop++|System Management
 Caprine|Internet
 Cawbird|Internet
 Chiaki|Games
 Chromium|Internet/Browsers
 Chromium Widevine|Multimedia
-Clam Antivirus|Tools
+Clam Antivirus|System Management
 CloudBuddy|Internet
-Codex|Editors
+Codex|Programming
 Color Emoji font|Appearance
-CommanderPi|Tools
+CommanderPi|System Management
 Conky|Appearance
 Conky Rings|Appearance
-Cool Retro Term|Appearance
-Cura|Editors
+Cool Retro Term|Terminals
+Cura|Engineering
 DDnet|Games
 Deluge|Internet
 Descent 1|Games
 Descent 2|Games
 Deskreen|Internet
 Discord|Internet
-Disk Usage Analyzer|Tools
+Disk Usage Analyzer|System Management
 Doom 3|Games
-Dot Matrix|Editors
+Dot Matrix|Creative Arts
 Downgrade Chromium|Internet/Browsers
-Drawing|Editors
+Drawing|Creative Arts
 Ducopanel|Tools
-Eagle CAD|Editors
-eDEX-UI|Appearance
+Eagle CAD|Engineering
+eDEX-UI|Terminals
 Email Checker|Internet
 Epiphany|Internet/Browsers
-ExaGear|Tools
+ExaGear|Tools/Emulation
 Falkon|Internet/Browsers
 FF Multi Converter|Tools
 Filezilla|Internet
 Firefox Rapid Release|Internet/Browsers
 Flameshot|Tools
-FreeCAD|Editors
+FreeCAD|Engineering
 FreeTube|Multimedia
-Fritzing|Editors
+Fritzing|Engineering
 Geany Dark Mode|Appearance
 Geekbench|Tools
-GIMP|Editors
-Github Desktop|Tools
-Github-CLI|Tools
+GIMP|Creative Arts
+Github Desktop|Programming
+Github-CLI|Programming
 Godot|Games
-GParted|Tools
-Guake Terminal|Tools
+GParted|System Management
+Guake Terminal|Terminals
 Heroes 2|Games
 Https File Server|Tools
 HTTrack Website Copier|Internet
-Hyper|Tools
+Hyper|Terminals
 Imager|Tools
-Inkscape|Editors
-Intellij IDEA|Editors
-jGRASP IDE|Editors
+Inkscape|Creative Arts
+Intellij IDEA|Programming
+jGRASP IDE|Programming
 KeePassXC|Tools
 Kodi|Multimedia
-Kolourpaint|Editors
-Lego Digital Designer|Editors
-LibreCAD|Editors
-LibreOffice|Editors
-Libreoffice MS theme|Appearance
-LibrePCB|Editors
+Kolourpaint|Creative Arts
+Lego Digital Designer|Creative Arts
+LibreCAD|Engineering
+LibreOffice|Office
+Libreoffice MS theme|Office
+LibrePCB|Engineering
 Lightpad|Appearance
 LineRider|Games
-LinuxCNC|Editors
+LinuxCNC|Engineering
 LMMS|Multimedia
 Lokinet|Internet
 Mac OS Theme|Appearance
-MatterControl|Editors
-Microsoft PowerShell|Tools
+MatterControl|Engineering
+Microsoft PowerShell|Terminals
 Microsoft Teams|Internet
 Minecraft Bedrock|Games
 Minecraft Java|Games
@@ -105,12 +105,12 @@ MuseScore2|hidden
 MuseScore|Multimedia
 Nautilus|Tools
 Nemo|Tools
-NixNote2|Editors
+NixNote2|Office
 Node.js|Tools
-Notepad ++|Editors
+Notepad ++|Programming
 OBS Studio|Multimedia
 Oomox Theme Designer|Appearance
-OpenSCAD|Editors
+OpenSCAD|Engineering
 Pale Moon|Internet/Browsers
 Persepolis Download Manager|Internet
 Pi-Apps Terminal Plugin (bash)|Tools
@@ -118,42 +118,42 @@ Pi-Apps Terminal Plugin (python)|Tools
 PiGro|Tools
 PiKISS GUI|Tools
 piKiss|Tools
-Pinta|Editors
-Pi Power Tools|Tools
+Pinta|Creative Arts
+Pi Power Tools|System Management
 PiSafe|Tools
 Powerline-Shell|Appearance
 PPSSPP (PSP emulator)|Games
-Processing IDE|Editors
-PrusaSlicer|Editors
+Processing IDE|Programming
+PrusaSlicer|Engineering
 Puffin|Internet/Browsers
-Pycharm CE|Editors
-QEMU|Tools
+Pycharm CE|Programming
+QEMU|Tools/Emulation
 Quartz|Internet/Browsers
 Raspi2png|Tools
 Reaper|Multimedia
-Remarkable|Editors
+Remarkable|Programming
 Renoise (Demo)|Multimedia
-Scratch 2|Editors
-Scratch 3|Editors
+Scratch 2|Programming
+Scratch 3|Programming
 Scrcpy|Tools
 Screenshot|Tools
-Shotwell|Editors
+Shotwell|Creative Arts
 SimpleScreenRecorder|Multimedia
 Snapdrop|Tools
 Snap Store|Tools
 Sonic Pi|Multimedia
 SpeedTest-CLI|Internet
-StackEdit|Editors
+StackEdit|Programming
 Steam|Games
 Steam Link|Games
 Stunt Rally|Games
-Sublime Text|Editors
-Synaptic|Tools
-Syncthing|Tools
-SysMonTask|Tools
-Sysmon|Tools
-System Monitoring Center|Tools
-Tabby|Tools
+Sublime Text|Programming
+Synaptic|System Management
+Syncthing|System Management
+SysMonTask|System Management
+Sysmon|System Management
+System Monitoring Center|System Management
+Tabby|Terminals
 TBOPlayer|Multimedia
 TeamViewer Host|Internet
 Telegram|Internet
@@ -162,20 +162,20 @@ Temps|Tools
 Tetris CLI|Games
 Thunderbird|Internet
 TiLP|Tools
-Timeshift|Tools
+Timeshift|System Management
 tldr|Tools
 Tor|Internet/Browsers
 Transmission|Internet
-Turbowarp|Editors
+Turbowarp|Programming
 Ulauncher|Appearance
 Unciv|Games
-Update Buddy|Tools
+Update Buddy|System Management
 USBImager|Tools
 VeraCrypt|Tools
-Visual Studio Code|Editors
+Visual Studio Code|Programming
 Vivaldi|Internet/Browsers
 VMware Horizon Client|Tools
-VSCodium|Editors
+VSCodium|Programming
 WACUP (new WinAmp)|Multimedia
 Waveform|Multimedia
 Web Apps|Internet
@@ -184,8 +184,8 @@ WhatsApp|Internet
 Windows 10 Theme|Appearance
 Windows Flasher|Tools
 Windows Screensavers|Appearance
-Wine (x86)|Tools
-WPS Office|Editors
+Wine (x86)|Tools/Emulation
+WPS Office|Office
 XMRig|Tools
 XSnow|Appearance
 Xtreme Download Manager|Internet


### PR DESCRIPTION
Removed Categories (number of apps in that category):
Editors (40)

Added Categories:
Programming (19)
System Management (16)
Creative Arts (10)
CAD and Manufacturing (10)
Terminals (7)
Office (4)

New subcategory under tools:
Emulation (5)

these are just ideas. looking for feedback. 

I've considered having System Management as a subcategory under tools instead of its own primary category, same goes for Terminals. 

Programming definitely deserves its own category. Appearance has shrunk because of apps moving to better fit categories (12 apps now). 

Office and CAD and Manufacturing are on the small side, but I fee like they deserve primary categories, or otherwise put them as subcategories under tools. I wanted to move apps our of tools because it was such a massive category before, 62 apps, and shrunk to 39 apps now.

closes https://github.com/Botspot/pi-apps/issues/1446