### PR TITLE
update_apps: use github api token to get release

### DIFF
--- a/.github/workflows/update_apps.yml
+++ b/.github/workflows/update_apps.yml
@@ -32,11 +32,11 @@ jobs:
 
           #add special functions
           get_release() {
-            curl --silent "https://api.github.com/repos/$1/releases/latest" | jq -r '.tag_name' | sed s/v//g
+            curl -s --header "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" "https://api.github.com/repos/$1/releases/latest" | jq -r '.tag_name' | sed s/v//g
           }
 
           get_prerelease() {
-            curl --silent "https://api.github.com/repos/$1/releases" | jq -r 'map(select(.prerelease)) | first | .tag_name' | sed s/v//g
+            curl -s --header "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" "https://api.github.com/repos/$1/releases" | jq -r 'map(select(.prerelease)) | first | .tag_name' | sed s/v//g
           }
 
           function validate_url(){


### PR DESCRIPTION
GitHub's API is rate-limited to 600 requests per hour, per IP. This may cause issues in the future if we have too many scripts fetching the latest release/prerelease. The limit can be increased to 5,000 requests per hour if an API token is used.

I have used this same method in the project afterburner [update scripts](https://github.com/ProjectAfterBurner/update-scripts/blob/main/api).