### PR TITLE
feature: support movable GUI

### DIFF
--- a/gui
+++ b/gui
@@ -686,8 +686,8 @@ if [[ "$guimode" == yad* ]];then
       --list --no-headers --column=:IMG  --column=Name --column=Sysname:HD --column=tip:HD --column=@fore@:HD \
       --separator='\n' --window-icon="${DIRECTORY}/icons/logo.png" \
       --tooltip-column=4 \
-      --dclick-action "env pipe=$pipe geometry2=$geometry2 '${DIRECTORY}/gui'" --select-action "env pipe=$pipe geometry2=$geometry2 '${DIRECTORY}/gui'" \
-      --button="!${DIRECTORY}/icons/search.png"!'Search':"env pipe=$pipe geometry2=$geometry2 '${DIRECTORY}/gui' '' '' Search/ Search/" \
+      --dclick-action "env pipe=$pipe '${DIRECTORY}/gui'" --select-action "env pipe=$pipe '${DIRECTORY}/gui'" \
+      --button="!${DIRECTORY}/icons/search.png"!'Search':"env pipe=$pipe '${DIRECTORY}/gui' '' '' Search/ Search/" \
       --button="!${DIRECTORY}/icons/options.png"!'Settings':2 \
       "$geometry1"
     

--- a/gui
+++ b/gui
@@ -508,37 +508,32 @@ get_positions() {
     main_yad_window=$YAD_XID
     if [ -n "${main_yad_window}" ]; then
       window_info=$(xwininfo -id $main_yad_window)
-      main_yad_window_pos=($(echo "$window_info" | grep "Corners:" | awk '{print $2}' | tr '+' '\n' | tr '-' '-\n' | sed '/^$/d'))
-      main_yad_window_width=$(echo "$window_info" | grep 'Width:' | awk '{print $2}')
-      main_yad_window_height=$(echo "$window_info" | grep 'Height:' | awk '{print $2}')
-      extents=$(xprop _NET_FRAME_EXTENTS -id "$main_yad_window" | grep "NET_FRAME_EXTENTS" | cut -d '=' -f 2 | tr -d ' ')
-      bl=$(echo $extents | cut -d ',' -f 1) # width of left border
-      br=$(echo $extents | cut -d ',' -f 2) # width of right border
-      t=$(echo $extents | cut -d ',' -f 3)  # height of title bar
-      bb=$(echo $extents | cut -d ',' -f 4) # height of bottom border
-      main_yad_window_pos[0]=$((main_yad_window_pos[0]-bl))
-      main_yad_window_pos[1]=$((main_yad_window_pos[1]-t))
-      #xdotool getwindowgeometry $main_yad_window | awk '{print $2}' | sed -n 2p | tr ',' '\n'
-      #xwininfo -id $main_yad_window | grep "Corners:" | awk '{print $2}' | tr '+' '\n' | tr '-' '-\n' | sed '/^$/d'
-      echo "${main_yad_window_pos[@]}" >/dev/stderr
-      echo "$main_yad_window" >/dev/stderr
+      # for speed of execution, we are assuming the order of matches from xwininfo
+      # this is safe as the output order has been standardized for over a decade
+      main_yad_window_pos=($(echo "$window_info" | sed -n 's/Absolute upper-left.*://p'))
+      main_yad_window_dim=($(echo "$window_info" | sed -n 's/Width://p;s/Height://p'))
+      # again, for speed, all border widths are saved to one array
+      # left, right, title, bottom [0, 1, 2, 3]
+      border_widths=($(xprop _NET_FRAME_EXTENTS -id "$main_yad_window" | sed -n  's/_NET_FRAME_EXTENTS.*=//p' | tr ',' '\n'))
+      main_yad_window_pos[0]=$((main_yad_window_pos[0]-border_widths[0]))
+      main_yad_window_pos[1]=$((main_yad_window_pos[1]-border_widths[2]))
       #total dimensions for both yad windows side by side
       if [ $screen_width -le 1000 ] || [ $screen_height -le 600 ];then
         #gui size for small screens
-        height=$main_yad_window_height
+        height=${main_yad_window_dim[1]}
         width=600
         
         #width of first window
-        width1=$main_yad_window_width
+        width1=${main_yad_window_dim[0]}
         #width of second window
         width2=$((width - width1))
       else
         #gui size for large screens
-        height=$main_yad_window_height
+        height=${main_yad_window_dim[1]}
         width=800
         
         #width of first window
-        width1=$main_yad_window_width
+        width1=${main_yad_window_dim[0]}
         #width of second window
         width2=$((width - width1))
       fi
@@ -549,7 +544,7 @@ get_positions() {
       #use current position
       xoffset1="${main_yad_window_pos[0]}"
       #screen offsets for window 2
-      xoffset2=$((xoffset1+width1+bl+br))
+      xoffset2=$((xoffset1+width1+border_widths[0]+border_widths[1]))
       
       #set completed location arguments for both yad windows
       geometry1="--geometry=${width1}x${height}+${xoffset1}+${yoffset}"

--- a/gui
+++ b/gui
@@ -507,7 +507,10 @@ get_positions() {
     # this allows for windows to be moved by the user and the second window to still show up where expected
     main_yad_window=$YAD_XID
     if [ -n "${main_yad_window}" ]; then
-      main_yad_window_pos=($(xwininfo -id $main_yad_window | grep "Corners:" | awk '{print $2}' | tr '+' '\n' | tr '-' '-\n' | sed '/^$/d'))
+      window_info=$(xwininfo -id $main_yad_window)
+      main_yad_window_pos=($(echo "$window_info" | grep "Corners:" | awk '{print $2}' | tr '+' '\n' | tr '-' '-\n' | sed '/^$/d'))
+      main_yad_window_width=$(echo "$window_info" | grep 'Width:' | awk '{print $2}')
+      main_yad_window_height=$(echo "$window_info" | grep 'Height:' | awk '{print $2}')
       extents=$(xprop _NET_FRAME_EXTENTS -id "$main_yad_window" | grep "NET_FRAME_EXTENTS" | cut -d '=' -f 2 | tr -d ' ')
       bl=$(echo $extents | cut -d ',' -f 1) # width of left border
       br=$(echo $extents | cut -d ',' -f 2) # width of right border
@@ -522,20 +525,20 @@ get_positions() {
       #total dimensions for both yad windows side by side
       if [ $screen_width -le 1000 ] || [ $screen_height -le 600 ];then
         #gui size for small screens
-        height=400
+        height=$main_yad_window_height
         width=600
         
         #width of first window
-        width1=250
+        width1=$main_yad_window_width
         #width of second window
         width2=$((width - width1))
       else
         #gui size for large screens
-        height=600
+        height=$main_yad_window_height
         width=800
         
         #width of first window
-        width1=320
+        width1=$main_yad_window_width
         #width of second window
         width2=$((width - width1))
       fi
@@ -546,7 +549,7 @@ get_positions() {
       #use current position
       xoffset1="${main_yad_window_pos[0]}"
       #screen offsets for window 2
-      xoffset2=$((xoffset1+width1))
+      xoffset2=$((xoffset1+width1+bl+br))
       
       #set completed location arguments for both yad windows
       geometry1="--geometry=${width1}x${height}+${xoffset1}+${yoffset}"

--- a/gui
+++ b/gui
@@ -505,7 +505,7 @@ get_positions() {
     # if this is being run by yad, there should be a yad window id
     # store in arrary of x and y
     # this allows for windows to be moved by the user and the second window to still show up where expected
-    main_yad_window=$(xdotool search --name ^Pi-Apps$)
+    main_yad_window=$YAD_XID
     if [ -n "${main_yad_window}" ]; then
       main_yad_window_pos=($(xwininfo -id $main_yad_window | grep "Corners:" | awk '{print $2}' | tr '+' '\n' | tr '-' '-\n' | sed '/^$/d'))
       extents=$(xprop _NET_FRAME_EXTENTS -id "$main_yad_window" | grep "NET_FRAME_EXTENTS" | cut -d '=' -f 2 | tr -d ' ')

--- a/gui
+++ b/gui
@@ -510,13 +510,14 @@ get_positions() {
       window_info=$(xwininfo -id $main_yad_window)
       # for speed of execution, we are assuming the order of matches from xwininfo
       # this is safe as the output order has been standardized for over a decade
+      # this is the location of where the window content starts inside the title bar and window borders (pos x then pos y)
       main_yad_window_pos=($(echo "$window_info" | sed -n 's/Absolute upper-left.*://p'))
+      # these are the dimensions of where the window content starts inside the title bar and window borders (dim x then dim y)
       main_yad_window_dim=($(echo "$window_info" | sed -n 's/Width://p;s/Height://p'))
       # again, for speed, all border widths are saved to one array
       # left, right, title, bottom [0, 1, 2, 3]
+      # this is the size of the window borders (including title bar)
       border_widths=($(xprop _NET_FRAME_EXTENTS -id "$main_yad_window" | sed -n  's/_NET_FRAME_EXTENTS.*=//p' | tr ',' '\n'))
-      main_yad_window_pos[0]=$((main_yad_window_pos[0]-border_widths[0]))
-      main_yad_window_pos[1]=$((main_yad_window_pos[1]-border_widths[2]))
       #total dimensions for both yad windows side by side
       if [ $screen_width -le 1000 ] || [ $screen_height -le 600 ];then
         #gui size for small screens
@@ -537,20 +538,20 @@ get_positions() {
         #width of second window
         width2=$((width - width1))
       fi
-      #how far down from the top of screen should both windows be?
-      yoffset="${main_yad_window_pos[1]}"
+      #how far down the top of the title bar of yad window is from the top of the screen
+      yoffset=$((main_yad_window_pos[1]-border_widths[2]))
       
       #screen offsets for window 1
-      #use current position
-      xoffset1="${main_yad_window_pos[0]}"
+      #use current position of the left side of the main window border
+      xoffset1=$((main_yad_window_pos[0]-border_widths[0]))
       #screen offsets for window 2
-      xoffset2=$((xoffset1+width1+border_widths[0]+border_widths[1]))
+      #use current position of the right side of the main window border
+      xoffset2=$((xoffset1+border_widths[0]+width1+border_widths[1]))
       
       #set completed location arguments for both yad windows
       geometry1="--geometry=${width1}x${height}+${xoffset1}+${yoffset}"
       geometry2="--geometry=${width2}x${height}+${xoffset2}+${yoffset}"
     else
-      unset main_yad_window_pos
       # default positions when the main window does not exist yet
       #total dimensions for both yad windows side by side
       if [ $screen_width -le 1000 ] || [ $screen_height -le 600 ];then
@@ -572,7 +573,7 @@ get_positions() {
         #width of second window
         width2=$((width - width1))
       fi
-      #how far down from the top of screen should both windows be?
+      #how far down the top of the title bar of yad window is from the top of the screen
       yoffset=$(((screen_height/2)-(height/2)))
       
       #screen offsets for window 1

--- a/gui
+++ b/gui
@@ -527,7 +527,7 @@ get_positions() {
         #width of first window
         width1=${main_yad_window_dim[0]}
         #width of second window
-        width2=$((width - width1))
+        width2=350
       else
         #gui size for large screens
         height=${main_yad_window_dim[1]}
@@ -536,7 +536,7 @@ get_positions() {
         #width of first window
         width1=${main_yad_window_dim[0]}
         #width of second window
-        width2=$((width - width1))
+        width2=480
       fi
       #how far down the top of the title bar of yad window is from the top of the screen
       yoffset=$((main_yad_window_pos[1]-border_widths[2]))

--- a/gui
+++ b/gui
@@ -106,6 +106,7 @@ if [ ! -z "$3" ];then
   
   if [[ "$input" == *'Updates/' ]];then
     #updater window
+    get_positions
     
     "${DIRECTORY}/updater" gui fast $geometry2 --skip-taskbar --close-on-unfocus
     exitcode=$? #0 if update successful, 1 if list of updates was closed
@@ -118,6 +119,7 @@ if [ ! -z "$3" ];then
     fi
   elif [ "$input" == 'Search/' ];then
     #search window
+    get_positions
     
     source "${DIRECTORY}/api" #to set the yadflags array variable
     
@@ -234,6 +236,7 @@ if [ ! -z "$3" ];then
       done) &
     
     #display app details window
+    get_positions
     (cat "${DIRECTORY}/apps/$app/description" || echo "Description unavailable") | yad --text-info --fontname=12 --wrap --show-uri \
       --text="$(sed 's/&/&amp;/g' <<<"$abovetext")" \
       "${imageline[@]}" \
@@ -426,7 +429,7 @@ EOF
 
 #install dependencies
 runonce <<"EOF"
-  dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool'
+  dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils'
   # Install dependencies if necessary
   if ! dpkg -s $dependencies >/dev/null 2>&1; then
     pkexec apt install $dependencies -y -f --no-install-recommends
@@ -485,7 +488,7 @@ guimode="$(cat "${DIRECTORY}/data/settings/App List Style")"
 
 #In YAD mode, two windows are handled in a side-by-side configuration. As a group, they must be centered on the the screen.
 #In Xlunch mode, the window must be centered, but xlunch only handles absolute offsets.
-{
+get_positions() {
   #determine screen_width and screen_height
   screen_dimensions="$(xrandr --nograb --current | awk -F 'connected |\\+|\\('  '/ connected.*[0-9]+x[0-9]+\+/ && $2 {printf $2 ", "}' | sed -n -e 's/^.*primary //p' | tr 'x+' ' ' | tr ',+' ' ')"
   if [ -z "$screen_dimensions" ];then
@@ -498,37 +501,91 @@ guimode="$(cat "${DIRECTORY}/data/settings/App List Style")"
   unset screen_dimensions
   
   if [[ "$guimode" == yad* ]];then
-    #total dimensions for both yad windows side by side
-    if [ $screen_width -le 1000 ] || [ $screen_height -le 600 ];then
-      #gui size for small screens
-      height=400
-      width=600
+
+    # if this is being run by yad, there should be a yad window id
+    # store in arrary of x and y
+    # this allows for windows to be moved by the user and the second window to still show up where expected
+    main_yad_window=$(xdotool search --name ^Pi-Apps$)
+    if [ -n "${main_yad_window}" ]; then
+      main_yad_window_pos=($(xwininfo -id $main_yad_window | grep "Corners:" | awk '{print $2}' | tr '+' '\n' | tr '-' '-\n' | sed '/^$/d'))
+      extents=$(xprop _NET_FRAME_EXTENTS -id "$main_yad_window" | grep "NET_FRAME_EXTENTS" | cut -d '=' -f 2 | tr -d ' ')
+      bl=$(echo $extents | cut -d ',' -f 1) # width of left border
+      br=$(echo $extents | cut -d ',' -f 2) # width of right border
+      t=$(echo $extents | cut -d ',' -f 3)  # height of title bar
+      bb=$(echo $extents | cut -d ',' -f 4) # height of bottom border
+      main_yad_window_pos[0]=$((main_yad_window_pos[0]-bl))
+      main_yad_window_pos[1]=$((main_yad_window_pos[1]-t))
+      #xdotool getwindowgeometry $main_yad_window | awk '{print $2}' | sed -n 2p | tr ',' '\n'
+      #xwininfo -id $main_yad_window | grep "Corners:" | awk '{print $2}' | tr '+' '\n' | tr '-' '-\n' | sed '/^$/d'
+      echo "${main_yad_window_pos[@]}" >/dev/stderr
+      echo "$main_yad_window" >/dev/stderr
+      #total dimensions for both yad windows side by side
+      if [ $screen_width -le 1000 ] || [ $screen_height -le 600 ];then
+        #gui size for small screens
+        height=400
+        width=600
+        
+        #width of first window
+        width1=250
+        #width of second window
+        width2=$((width - width1))
+      else
+        #gui size for large screens
+        height=600
+        width=800
+        
+        #width of first window
+        width1=320
+        #width of second window
+        width2=$((width - width1))
+      fi
+      #how far down from the top of screen should both windows be?
+      yoffset="${main_yad_window_pos[1]}"
       
-      #width of first window
-      width1=250
-      #width of second window
-      width2=$((width - width1))
+      #screen offsets for window 1
+      #use current position
+      xoffset1="${main_yad_window_pos[0]}"
+      #screen offsets for window 2
+      xoffset2=$((xoffset1+width1))
+      
+      #set completed location arguments for both yad windows
+      geometry1="--geometry=${width1}x${height}+${xoffset1}+${yoffset}"
+      geometry2="--geometry=${width2}x${height}+${xoffset2}+${yoffset}"
     else
-      #gui size for large screens
-      height=600
-      width=800
+      unset main_yad_window_pos
+      # default positions when the main window does not exist yet
+      #total dimensions for both yad windows side by side
+      if [ $screen_width -le 1000 ] || [ $screen_height -le 600 ];then
+        #gui size for small screens
+        height=400
+        width=600
+        
+        #width of first window
+        width1=250
+        #width of second window
+        width2=$((width - width1))
+      else
+        #gui size for large screens
+        height=600
+        width=800
+        
+        #width of first window
+        width1=320
+        #width of second window
+        width2=$((width - width1))
+      fi
+      #how far down from the top of screen should both windows be?
+      yoffset=$(((screen_height/2)-(height/2)))
       
-      #width of first window
-      width1=320
-      #width of second window
-      width2=$((width - width1))
+      #screen offsets for window 1
+      xoffset1=$(((screen_width/2)-(width/2)))
+      #screen offsets for window 2
+      xoffset2=$(((screen_width/2)-(width/2)+width1))
+      
+      #set completed location arguments for both yad windows
+      geometry1="--geometry=${width1}x${height}+${xoffset1}+${yoffset}"
+      geometry2="--geometry=${width2}x${height}+${xoffset2}+${yoffset}"
     fi
-    #how far down from the top of screen should both windows be?
-    yoffset=$(((screen_height/2)-(height/2)))
-    
-    #screen offsets for window 1
-    xoffset1=$(((screen_width/2)-(width/2)))
-    #screen offsets for window 2
-    xoffset2=$(((screen_width/2)-(width/2)+width1))
-    
-    #set completed location arguments for both yad windows
-    geometry1="--geometry=${width1}x${height}+${xoffset1}+${yoffset}"
-    geometry2="--geometry=${width2}x${height}+${xoffset2}+${yoffset}"
     
   elif [[ "$guimode" == xlunch* ]];then
     #desired dimensions for xlunch window
@@ -541,6 +598,8 @@ guimode="$(cat "${DIRECTORY}/data/settings/App List Style")"
     error "Unrecognized app list style '$guimode'!"
   fi
 }
+# run get_positions once incase sometime requires the position value immediatly
+get_positions
 
 #Compile xlunch if required
 if [[ "$guimode" == xlunch* ]] && ([ ! -d "${DIRECTORY}/xlunch" ] || [ ! -f /usr/bin/xlunch ]);then

--- a/install
+++ b/install
@@ -23,7 +23,7 @@ fi
 sudo apt update || error "The command 'sudo apt update' failed. Before Pi-Apps will work, you must fix your apt package-management system."
 
 #install dependencies
-dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool'
+dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils'
 
 if ! dpkg -s $dependencies &>/dev/null ;then
   sudo apt install $dependencies -y -f --no-install-recommends


### PR DESCRIPTION
creating as a draft since this needs testing on piOS and many DEs to see if they all behave. yes obtaining the window size as well as the headers/buffer sizes separately was necessary.

this obtains the current main yad window position, and size

this relies on the window manager not lying so it needs to be tested on multiple systems

this can be extended to allow the user to resize the main UI as well to automatically change the size of the second yad window (like if the user makes the main UI window taller/smaller, then the second window can be automatically made taller/smaller)

https://user-images.githubusercontent.com/28281419/169632418-35bf79e8-fe50-4889-a56b-c93d17755b7f.mp4


