### PR TITLE
Use proper Debian Version for Flameshot

### DIFF
--- a/apps/Flameshot/install-32
+++ b/apps/Flameshot/install-32
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 version=11.0.0
-debian_version="$(cat /etc/os-release | grep -oPm1 '(?<=VERSION=")\d+')"
-install_packages https://github.com/flameshot-org/flameshot/releases/download/v${version}/flameshot-${version}-1.debian-${debian_version}.armhf.deb || exit 1
+install_packages https://github.com/flameshot-org/flameshot/releases/download/v${get_codename}/flameshot-${version}-1.debian-${get_codename}.armhf.deb || exit 1

--- a/apps/Flameshot/install-32
+++ b/apps/Flameshot/install-32
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 version=11.0.0
-debian_version="$(cat /etc/debian_version | grep -o '^.[1-9]*')"
+debian_version="$(cat /etc/os-release | grep -om1 '[0-9]*')"
 install_packages https://github.com/flameshot-org/flameshot/releases/download/v${version}/flameshot-${version}-1.debian-${debian_version}.armhf.deb || exit 1

--- a/apps/Flameshot/install-32
+++ b/apps/Flameshot/install-32
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 version=11.0.0
-debian_version="$(cat /etc/os-release | grep -om1 '[0-9]*')"
+debian_version="$(cat /etc/os-release | grep -oPm1 '(?<=VERSION=")\d+')"
 install_packages https://github.com/flameshot-org/flameshot/releases/download/v${version}/flameshot-${version}-1.debian-${debian_version}.armhf.deb || exit 1

--- a/apps/Flameshot/install-32
+++ b/apps/Flameshot/install-32
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 version=11.0.0
-install_packages https://github.com/flameshot-org/flameshot/releases/download/v${get_codename}/flameshot-${version}-1.debian-${get_codename}.armhf.deb || exit 1
+install_packages https://github.com/flameshot-org/flameshot/releases/download/v${version}/flameshot-${version}-1.debian-${get_codename}.armhf.deb || exit 1

--- a/apps/Flameshot/install-32
+++ b/apps/Flameshot/install-32
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 version=11.0.0
-install_packages https://github.com/flameshot-org/flameshot/releases/download/v${version}/flameshot-${version}-1.debian-10.armhf.deb || exit 1
+debian_version="$(cat /etc/debian_version | grep -o '^.[1-9]*')"
+install_packages https://github.com/flameshot-org/flameshot/releases/download/v${version}/flameshot-${version}-1.debian-${debian_version}.armhf.deb || exit 1

--- a/apps/Flameshot/install-64
+++ b/apps/Flameshot/install-64
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 version=11.0.0
-debian_version="$(cat /etc/os-release | grep -oPm1 '(?<=VERSION=")\d+')"
-install_packages https://github.com/flameshot-org/flameshot/releases/download/v${version}/flameshot-${version}-1.debian-${debian_version}.arm64.deb || exit 1
+install_packages https://github.com/flameshot-org/flameshot/releases/download/v${version}/flameshot-${version}-1.debian-${get_codename}.arm64.deb || exit 1

--- a/apps/Flameshot/install-64
+++ b/apps/Flameshot/install-64
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 version=11.0.0
-debian_version="$(cat /etc/os-release | grep -om1 '[0-9]*')"
+debian_version="$(cat /etc/os-release | grep -oPm1 '(?<=VERSION=")\d+')"
 install_packages https://github.com/flameshot-org/flameshot/releases/download/v${version}/flameshot-${version}-1.debian-${debian_version}.arm64.deb || exit 1

--- a/apps/Flameshot/install-64
+++ b/apps/Flameshot/install-64
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 version=11.0.0
-debian_version="$(cat /etc/debian_version | grep -o '^.[1-9]*')"
+debian_version="$(cat /etc/os-release | grep -om1 '[0-9]*')"
 install_packages https://github.com/flameshot-org/flameshot/releases/download/v${version}/flameshot-${version}-1.debian-${debian_version}.arm64.deb || exit 1

--- a/apps/Flameshot/install-64
+++ b/apps/Flameshot/install-64
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 version=11.0.0
-install_packages https://github.com/flameshot-org/flameshot/releases/download/v${version}/flameshot-${version}-1.debian-10.arm64.deb || exit 1
+debian_version="$(cat /etc/debian_version | grep -o '^.[1-9]*')"
+install_packages https://github.com/flameshot-org/flameshot/releases/download/v${version}/flameshot-${version}-1.debian-${debian_version}.arm64.deb || exit 1


### PR DESCRIPTION
Flameshot releases separate packages for Debian 10 & Debian 11.
For example in current latest [release](https://github.com/flameshot-org/flameshot/releases/tag/v11.0.0), there is 2 armhf deb files:
[flameshot-11.0.0-1.debian-10.armhf.deb](https://github.com/flameshot-org/flameshot/releases/download/v11.0.0/flameshot-11.0.0-1.debian-10.armhf.deb) &
[flameshot-11.0.0-1.debian-11.armhf.deb](https://github.com/flameshot-org/flameshot/releases/download/v11.0.0/flameshot-11.0.0-1.debian-11.armhf.deb)
However we are only using the Debian 10 version for some reason.
This pr reads debian version from `/etc/debian_version` and uses it to provide the version number.
**EDIT:** Now it uses `/etc/os-release` for suggestions.