### PR TITLE
box86: use /usr/share/keyrings

### DIFF
--- a/apps/Box86/install-32
+++ b/apps/Box86/install-32
@@ -5,10 +5,9 @@ fi
 
 sudo rm -f /etc/apt/sources.list.d/box86.list
 echo "Adding box86 repo..."
-sudo mkdir -p /etc/apt/sources.list.d
 sudo wget https://itai-nelken.github.io/weekly-box86-debs/debian/box86.list -O /etc/apt/sources.list.d/box86.list || error "Failed to download /etc/apt/sources.list.d/box86.list"
 echo "Adding key..."
-wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo apt-key add - || error "Failed to add key to box86 repo!"
+curl -fsSL https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/box86-archive-keyring.gpg || error "Failed to add key to box86 repo!"
 echo "Installing box86..."
 sudo dpkg --remove box86-no-binfmt-restart 2>/dev/null
 install_packages box86 || exit 1

--- a/apps/Box86/install-32
+++ b/apps/Box86/install-32
@@ -5,7 +5,7 @@ fi
 
 sudo rm -f /etc/apt/sources.list.d/box86.list
 echo "Adding box86 repo..."
-sudo wget https://itai-nelken.github.io/weekly-box86-debs/debian/box86.list -O /etc/apt/sources.list.d/box86.list || error "Failed to download /etc/apt/sources.list.d/box86.list"
+echo "deb [signed-by=/usr/share/keyrings/box86-archive-keyring.gpg] https://itai-nelken.github.io/weekly-box86-debs/debian/ /" | sudo tee /etc/apt/sources.list.d/box86.list >/dev/null || error "Failed to download /etc/apt/sources.list.d/box86.list"
 echo "Adding key..."
 curl -fsSL https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/box86-archive-keyring.gpg || error "Failed to add key to box86 repo!"
 echo "Installing box86..."

--- a/apps/Box86/install-64
+++ b/apps/Box86/install-64
@@ -34,7 +34,7 @@ fi
 
 sudo rm /etc/apt/sources.list.d/box86.list &>/dev/null
 echo "Adding box86 repo..."
-wget https://itai-nelken.github.io/weekly-box86-debs/debian/box86.list -qO- | sed -r 's/deb /deb [arch=armhf] /' | sudo tee /etc/apt/sources.list.d/box86.list >/dev/null|| error "Failed to download /etc/apt/sources.list.d/box86.list"
+echo "deb [arch=armhf] [signed-by=/usr/share/keyrings/box86-archive-keyring.gpg] https://itai-nelken.github.io/weekly-box86-debs/debian/ /" | sudo tee /etc/apt/sources.list.d/box86.list >/dev/null || error "Failed to download /etc/apt/sources.list.d/box86.list"
 echo "Adding key..."
 curl -fsSL https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/box86-archive-keyring.gpg || error "Failed to add key to box86 repo!"
 echo "Installing box86..."

--- a/apps/Box86/install-64
+++ b/apps/Box86/install-64
@@ -36,7 +36,7 @@ sudo rm /etc/apt/sources.list.d/box86.list &>/dev/null
 echo "Adding box86 repo..."
 wget https://itai-nelken.github.io/weekly-box86-debs/debian/box86.list -qO- | sed -r 's/deb /deb [arch=armhf] /' | sudo tee /etc/apt/sources.list.d/box86.list >/dev/null|| error "Failed to download /etc/apt/sources.list.d/box86.list"
 echo "Adding key..."
-wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo apt-key add - || error "Failed to add key to box86 repo!"
+curl -fsSL https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/box86-archive-keyring.gpg || error "Failed to add key to box86 repo!"
 echo "Installing box86..."
 sudo dpkg --remove box86-no-binfmt-restart 2>/dev/null
 install_packages box86:armhf || exit 1

--- a/apps/Box86/uninstall
+++ b/apps/Box86/uninstall
@@ -12,11 +12,10 @@ purge_packages || exit 1
 echo "removing box86 repo..."
 sudo rm -f /etc/apt/sources.list.d/box86.list || error "Failed to remove repo!"
 echo "removing box86 repo key..."
-sudo apt-key remove "5DBC E818 72C0 609D 3C47  61AA EB3C E9A3 37EC DFA4" || error "Failed to remove key!"
+sudo rm -f /usr/share/keyrings/box86-archive-keyring.gpg || error "Failed to remove key!"
 #to set $arch variable
 source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"
 if [ "$arch" == 64 ]; then
-  
   sudo dpkg --remove-architecture armhf || warning "armhf architecture should be removed by now, but it isn't!"
   check-armhf
   if [[ "$ARMHF" == *"armhf"* ]]; then


### PR DESCRIPTION
`apt-key` is deprecated in Debian Bullseye, so we'll need to save the key in `/usr/share/keyrings` now.