### PR TITLE
api: add add_external_repo and rm_external_repo

### DIFF
--- a/api
+++ b/api
@@ -207,10 +207,16 @@ remove_repofile_if_unused() { #Given a sources.list.d file, delete it if nothing
   [ -z "$file" ] && error "remove_repo_if_unused: no sources.list.d file specified!"
   #return now if the list file does not exist
   [ -f "$file" ] || return 0
-  
-  #determine what repo-urls are in the file
-  local urls="$(cat "$file" | grep -v '^#' | tr ' ' '\n' | grep '://')"
-  
+
+  if [ "${file##*.}" == "list" ]; then
+    #determine what repo-urls are in the file
+    local urls="$(cat "$file" | grep -v '^#' | tr ' ' '\n' | grep '://')"
+  elif [ "${file##*.}" == "sources" ]; then
+    #determine what repo-urls are in the file
+    local urls="$(cat "$file" | grep -v '^#' | grep '^URIs: ' | sed 's/URIs: //g')"
+  else
+    error "$file was not of apt list or sources type"
+  fi
   #there could be multiple urls in one file. Check each url and set the in_use variable to 1 if any packages are found
   local IFS=$'\n'
   local in_use=0
@@ -225,7 +231,7 @@ remove_repofile_if_unused() { #Given a sources.list.d file, delete it if nothing
   if [ "$in_use" == 0 ] && [ "$testmode" == test ];then
     echo "The given repository is not in use and can be deleted:"$'\n'"$file" 1>&2
   elif [ "$in_use" == 0 ];then
-    status "Removing the $(basename "$file" | sed 's/.list$//g') repo as it is not being used"
+    status "Removing the $(basename "$file" | sed 's/.list$//g' | sed 's/.sources$//g') repo as it is not being used"
     sudo rm -f "$file"
     [ -f "$key" ] && sudo rm -f "$key" || true
   fi
@@ -704,19 +710,25 @@ debian_ppa_installer() { #setup a PPA on a Debian distro. Arguments: ppa_name di
 }
 
 add_external_repo() { # add an external apt repo and its gpg key.
-  # follows https://wiki.debian.org/DebianRepository/UseThirdParty specification with one-line-style format https://repolib.readthedocs.io/en/latest/deb822-format.html#one-line-format
+  # follows https://wiki.debian.org/DebianRepository/UseThirdParty specification with deb822 format https://repolib.readthedocs.io/en/latest/deb822-format.html
+  # required inputs
   local reponame="$1"
-  # "URI SUITE COMPONENT"
-  local repopath="$2"
-  local pubkeyurl="$3"
+  local pubkeyurl="$2"
+  local uris="$3"
+  local suites="$4"
+  # potentially optional inputs
+  # components is not used when suite is an absolute path
+  local components="$5"
+  # additional options can be specified as the 6th, 7th, 8th, etc argument (eg: "Architectures: arm64")
 
-  # check if all needed vars are set
-  [ -z "$repopath" ] && error "add_external_repo: repopath not set"
+  # check if all needed vars are set  
   [ -z "$reponame" ] && error "add_external_repo: reponame not set"
+  [ -z "$uris" ] && error "add_external_repo: uris not set"
+  [ -z "$suites" ] && error "add_external_repo: suites not set"
   [ -z "$pubkeyurl" ] && error "add_external_repo: pubkeyurl not set"
 
-  # exit if reponame contains space, since apt doesn't accept .list files with spaces in filename or keyname.
-  if [[ $reponame = *" "* ]]; then
+  # exit if reponame or uri or suite contains space
+  if [[ $reponame = *" "* ]] || [[ $uris = *" "* ]] || [[ $suites = *" "* ]]; then
     error "add_external_repo: provided reponame contains a space."
   fi
 
@@ -733,6 +745,11 @@ add_external_repo() { # add an external apt repo and its gpg key.
     sudo rm -f /etc/apt/sources.list.d/${reponame}.list || error "add_external_repo: failed to remove conflicting .list file."
   fi
 
+  # check if .sources file already exists
+  if [ -f /etc/apt/sources.list.d/${reponame}.sources ]; then
+    sudo rm -f /etc/apt/sources.list.d/${reponame}.sources || error "add_external_repo: failed to remove conflicting .sources file."
+  fi
+
   # download gpg key from specified url
   if [ -f /usr/share/keyrings/${reponame}-archive-keyring.gpg ]; then
     sudo rm -f /usr/share/keyrings/${reponame}-archive-keyring.gpg
@@ -740,16 +757,25 @@ add_external_repo() { # add an external apt repo and its gpg key.
   wget -qO- "$pubkeyurl" | sudo gpg --dearmor -o /usr/share/keyrings/${reponame}-archive-keyring.gpg
 
   if [ $? != 0 ];then
-    sudo rm -f /etc/apt/sources.list.d/${reponame}.list
+    sudo rm -f /etc/apt/sources.list.d/${reponame}.sources
     sudo rm -f /usr/share/keyrings/${reponame}-archive-keyring.gpg
     error "add_external_repo: download from specified pubkeyurl failed."
   fi
 
-  # create .list file
-  echo "deb [signed-by=/usr/share/keyrings/${reponame}-archive-keyring.gpg] $repopath" | sudo tee /etc/apt/sources.list.d/${reponame}.list >/dev/null
+  # create .sources file
+  echo "Types: deb
+URIs: $uris
+Suites: $suites" | sudo tee /etc/apt/sources.list.d/${reponame}.sources >/dev/null
+  if [ ! -z "$components" ]; then
+    echo "Components: $components" | sudo tee -a /etc/apt/sources.list.d/${reponame}.sources >/dev/null
+  fi
+  for input in "${@: 6}"; do
+    echo "$input" | sudo tee -a /etc/apt/sources.list.d/${reponame}.sources >/dev/null
+  done
+  echo "Signed-By: /usr/share/keyrings/${reponame}-archive-keyring.gpg" | sudo tee -a /etc/apt/sources.list.d/${reponame}.sources >/dev/null
 
   if [ $? != 0 ];then
-    sudo rm -f /etc/apt/sources.list.d/${reponame}.list
+    sudo rm -f /etc/apt/sources.list.d/${reponame}.sources
     sudo rm -f /usr/share/keyrings/${reponame}-archive-keyring.gpg
     error "add_external_repo: failed to create ${reponame}.list file"
   fi
@@ -767,27 +793,32 @@ rm_external_repo() { # remove an external apt repo and its gpg key, if the repo 
     error "rm_external_repo: provided reponame contains a space."
   fi
 
-  # exit gracefully if .list file does not exist
-  [ -f "/etc/apt/sources.list.d/$reponame.list" ] || exit 0
+  # always remove deprecated .list file if present
+  if [ -f /etc/apt/sources.list.d/${reponame}.list ]; then
+    sudo rm -f /etc/apt/sources.list.d/${reponame}.list
+  fi
+
+  # exit gracefully if .sources file does not exist
+  [ -f "/etc/apt/sources.list.d/$reponame.sources" ] || exit 0
   
   if [ "$force" == force ]; then
     rm -f /usr/share/keyrings/${reponame}-archive-keyring.gpg || error "rm_external_repo: removal of ${reponame}-archive-keyring.gpg failed"
-    sudo rm -f /etc/apt/sources.list.d/${reponame}.list || error "rm_external_repo: removal of ${reponame}.list failed"
+    sudo rm -f /etc/apt/sources.list.d/${reponame}.sources || error "rm_external_repo: removal of ${reponame}.sources failed"
     exit 0
   fi
 
-  remove_repofile_if_unused /etc/apt/sources.list.d/${reponame}.list "" /usr/share/keyrings/${reponame}-archive-keyring.gpg
+  remove_repofile_if_unused /etc/apt/sources.list.d/${reponame}.sources "" /usr/share/keyrings/${reponame}-archive-keyring.gpg
 }
 
 adoptium_installer() {
   case "$__os_codename" in
   bionic | focal | jammy | buster | bullseye | bookworm)
-    add_external_repo "adoptium" "https://adoptium.jfrog.io/artifactory/deb $__os_codename main" "https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public" || exit 1
+    add_external_repo "adoptium" "https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public" "https://adoptium.jfrog.io/artifactory/deb" "$__os_codename" "main" || exit 1
     ;;
   *)
     # use bionic target name explicitly for any other OS as its the oldest LTS target adoptium continues to support
     # all supported adoptium OSs use the same debs so the target specified does not actually matter
-    add_external_repo "adoptium" "https://adoptium.jfrog.io/artifactory/deb bionic main" "https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public" || exit 1
+    add_external_repo "adoptium" "https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public" "https://adoptium.jfrog.io/artifactory/deb" "bionic" "main" || exit 1
     ;;
   esac
   apt_update

--- a/api
+++ b/api
@@ -780,36 +780,19 @@ rm_external_repo() { # remove an external apt repo and its gpg key, if the repo 
 }
 
 adoptium_installer() {
-  status "Adding Adoptium repository:"
-
-  echo "- downloading public key"
-  rm -f /tmp/adoptium-public-key
-  wget -O /tmp/adoptium-public-key https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public || error "Failed to download adoptium public key"
-
-  echo " - storing binary format public key in /usr/share/keyrings"
-  # the dearmor command converts arbitrary input (OpenPGP ASCII armor or binary format) into binary format
-  cat /tmp/adoptium-public-key | gpg --dearmor | sudo tee /usr/share/keyrings/adoptium-archive-keyring.gpg >/dev/null
-  rm -f /tmp/adoptium-public-key
-
-  echo " - Creating /etc/apt/sources.list.d/adoptium.list"
   case "$__os_codename" in
   bionic | focal | jammy | buster | bullseye | bookworm)
-    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb $__os_codename main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
+    add_external_repo "adoptium" "https://adoptium.jfrog.io/artifactory/deb $__os_codename main" "https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public" || exit 1
     ;;
   *)
     # use bionic target name explicitly for any other OS as its the oldest LTS target adoptium continues to support
     # all supported adoptium OSs use the same debs so the target specified does not actually matter
-    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb bionic main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
+    add_external_repo "adoptium" "https://adoptium.jfrog.io/artifactory/deb bionic main" "https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public" || exit 1
     ;;
   esac
   apt_update
   if [ $? != 0 ]; then
-    anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb"
-    if [ $? != 0 ]; then
-      # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-      # safe to remove
-      sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
-    fi
+    rm_external_repo "adoptium"
     error "Failed to perform apt update after adding Adoptium repository."
   fi
 }

--- a/api
+++ b/api
@@ -703,6 +703,82 @@ debian_ppa_installer() { #setup a PPA on a Debian distro. Arguments: ppa_name di
   fi
 }
 
+add_external_repo() { # add an external apt repo and its gpg key.
+  # follows https://wiki.debian.org/DebianRepository/UseThirdParty specification with one-line-style format https://repolib.readthedocs.io/en/latest/deb822-format.html#one-line-format
+  local reponame="$1"
+  # "URI SUITE COMPONENT"
+  local repopath="$2"
+  local pubkeyurl="$3"
+
+  # check if all needed vars are set
+  [ -z "$repopath" ] && error "add_external_repo: repopath not set"
+  [ -z "$reponame" ] && error "add_external_repo: reponame not set"
+  [ -z "$pubkeyurl" ] && error "add_external_repo: pubkeyurl not set"
+
+  # exit if reponame contains space, since apt doesn't accept .list files with spaces in filename or keyname.
+  if [[ $reponame = *" "* ]]; then
+    error "add_external_repo: provided reponame contains a space."
+  fi
+
+  # check if links are valid
+  wget -q --spider "$pubkeyurl" || error "add_external_repo: pubkeyurl isn't a valid link"
+
+  # make apt keyring directory if it doesn't exist
+  if [ ! -d /usr/share/keyrings ]; then
+    sudo mkdir -p /usr/share/keyrings || error "add_external_repo: failed to create apt keyring directory."
+  fi
+
+  # check if .list file already exists
+  if [ -f /etc/apt/sources.list.d/${reponame}.list ]; then
+    sudo rm -f /etc/apt/sources.list.d/${reponame}.list || error "add_external_repo: failed to remove conflicting .list file."
+  fi
+
+  # download gpg key from specified url
+  if [ -f /usr/share/keyrings/${reponame}-archive-keyring.gpg ]; then
+    sudo rm -f /usr/share/keyrings/${reponame}-archive-keyring.gpg
+  fi 
+  wget -qO- "$pubkeyurl" | sudo gpg --dearmor -o /usr/share/keyrings/${reponame}-archive-keyring.gpg
+
+  if [ $? != 0 ];then
+    sudo rm -f /etc/apt/sources.list.d/${reponame}.list
+    sudo rm -f /usr/share/keyrings/${reponame}-archive-keyring.gpg
+    error "add_external_repo: download from specified pubkeyurl failed."
+  fi
+
+  # create .list file
+  echo "deb [signed-by=/usr/share/keyrings/${reponame}-archive-keyring.gpg] $repopath" | sudo tee /etc/apt/sources.list.d/${reponame}.list >/dev/null
+
+  if [ $? != 0 ];then
+    sudo rm -f /etc/apt/sources.list.d/${reponame}.list
+    sudo rm -f /usr/share/keyrings/${reponame}-archive-keyring.gpg
+    error "add_external_repo: failed to create ${reponame}.list file"
+  fi
+}
+
+rm_external_repo() { # remove an external apt repo and its gpg key, if the repo is no longer in use. (force-remove the repo with force argument)
+
+  local reponame="$1"
+  local force="$2"
+
+  [ -z "$reponame" ] && error "rm_external_repo: reponame not provided"
+
+  # exit if reponame contains space, since apt doesn't accept .list files with spaces in filename or keyname.
+  if [[ $reponame = *" "* ]]; then
+    error "rm_external_repo: provided reponame contains a space."
+  fi
+
+  # exit gracefully if .list file does not exist
+  [ -f "/etc/apt/sources.list.d/$reponame.list" ] || exit 0
+  
+  if [ "$force" == force ]; then
+    rm -f /usr/share/keyrings/${reponame}-archive-keyring.gpg || error "rm_external_repo: removal of ${reponame}-archive-keyring.gpg failed"
+    sudo rm -f /etc/apt/sources.list.d/${reponame}.list || error "rm_external_repo: removal of ${reponame}.list failed"
+    exit 0
+  fi
+
+  remove_repofile_if_unused /etc/apt/sources.list.d/${reponame}.list "" /usr/share/keyrings/${reponame}-archive-keyring.gpg
+}
+
 adoptium_installer() {
   status "Adding Adoptium repository:"
 

--- a/apps/Angry IP scanner/uninstall
+++ b/apps/Angry IP scanner/uninstall
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 purge_packages || exit 1
-remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list
+rm_external_repo "adoptium"

--- a/apps/Box64/install-64
+++ b/apps/Box64/install-64
@@ -4,19 +4,12 @@ if dpkg -l box64 &>/dev/null ;then
   sudo apt purge -y --allow-change-held-packages box64*
 fi
 
-sudo wget https://pi-apps-coders.github.io/box64-debs/box64.list -O /etc/apt/sources.list.d/box64.list
-if [ $? != 0 ];then
-  sudo rm -f /etc/apt/sources.list.d/box64.list
-  error "Failed to add box64.list file!"
-fi
+add_external_repo "box64" "https://Pi-Apps-Coders.github.io/box64-debs/debian ./" "https://pi-apps-coders.github.io/box64-debs/KEY.gpg" || exit 1
 
-sudo rm -f /usr/share/keyrings/box64-debs-archive-keyring.gpg /etc/apt/trusted.gpg.d/box64-debs-archive-keyring.gpg
-sudo mkdir -p /etc/apt/trusted.gpg.d
-wget -qO- https://pi-apps-coders.github.io/box64-debs/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box64-debs-archive-keyring.gpg > /dev/null
-
-if [ $? != 0 ];then
-  sudo rm -f /etc/apt/sources.list.d/box64.list
-  error "Failed to add KEY.gpg to APT keyring!"
+apt_update
+if [ $? != 0 ]; then
+  rm_external_repo "box64"
+  error "Failed to perform apt update after adding box64 repository."
 fi
 
 # obtain SOC_ID

--- a/apps/Box64/install-64
+++ b/apps/Box64/install-64
@@ -4,7 +4,7 @@ if dpkg -l box64 &>/dev/null ;then
   sudo apt purge -y --allow-change-held-packages box64*
 fi
 
-add_external_repo "box64" "https://Pi-Apps-Coders.github.io/box64-debs/debian ./" "https://pi-apps-coders.github.io/box64-debs/KEY.gpg" || exit 1
+add_external_repo "box64" "https://pi-apps-coders.github.io/box64-debs/KEY.gpg" "https://Pi-Apps-Coders.github.io/box64-debs/debian" "./" || exit 1
 
 apt_update
 if [ $? != 0 ]; then

--- a/apps/Box64/uninstall
+++ b/apps/Box64/uninstall
@@ -1,6 +1,7 @@
 #!/bin/bash
 purge_packages || exit 1
 
-sudo rm -f /etc/apt/sources.list.d/box64.list || error "Failed to remove repo!"
+# remove deprecated key locations
+sudo rm -f /usr/share/keyrings/box64-debs-archive-keyring.gpg /etc/apt/trusted.gpg.d/box64-debs-archive-keyring.gpg
 
-sudo rm -f /usr/share/keyrings/box64-debs-archive-keyring.gpg /etc/apt/trusted.gpg.d/box64-debs-archive-keyring.gpg || error "Failed to remove GPG key!"
+rm_external_repo "box64"

--- a/apps/Box86/install-32
+++ b/apps/Box86/install-32
@@ -9,7 +9,7 @@ if dpkg -l box86 &>/dev/null ;then
   sudo apt purge -y --allow-change-held-packages box86*
 fi
 
-add_external_repo "box86" "https://Pi-Apps-Coders.github.io/box86-debs/debian ./" "https://pi-apps-coders.github.io/box86-debs/KEY.gpg" || exit 1
+add_external_repo "box86" "https://pi-apps-coders.github.io/box86-debs/KEY.gpg" "https://Pi-Apps-Coders.github.io/box86-debs/debian" "./" || exit 1
 
 apt_update
 if [ $? != 0 ]; then

--- a/apps/Box86/install-32
+++ b/apps/Box86/install-32
@@ -9,19 +9,12 @@ if dpkg -l box86 &>/dev/null ;then
   sudo apt purge -y --allow-change-held-packages box86*
 fi
 
-sudo wget https://pi-apps-coders.github.io/box86-debs/box86.list -O /etc/apt/sources.list.d/box86.list
-if [ $? != 0 ];then
-  sudo rm -f /etc/apt/sources.list.d/box86.list
-  error "Failed to add box86.list file!"
-fi
+add_external_repo "box86" "https://Pi-Apps-Coders.github.io/box86-debs/debian ./" "https://pi-apps-coders.github.io/box86-debs/KEY.gpg" || exit 1
 
-sudo rm -f /usr/share/keyrings/box86-debs-archive-keyring.gpg /etc/apt/trusted.gpg.d/box86-debs-archive-keyring.gpg
-sudo mkdir -p /etc/apt/trusted.gpg.d
-wget -qO- https://pi-apps-coders.github.io/box86-debs/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box86-debs-archive-keyring.gpg > /dev/null
-
-if [ $? != 0 ];then
-  sudo rm -f /etc/apt/sources.list.d/box86.list
-  error "Failed to add KEY.gpg to APT keyring!"
+apt_update
+if [ $? != 0 ]; then
+  rm_external_repo "box86"
+  error "Failed to perform apt update after adding box86 repository."
 fi
 
 # obtain SOC_ID

--- a/apps/Box86/install-64
+++ b/apps/Box86/install-64
@@ -80,7 +80,7 @@ install_packages libc6:armhf libstdc++6:armhf \
   libgssapi-krb5-2:armhf libkrb5-3:armhf \
   $rpi_arm_userspace $mesa_va_drivers libegl1:armhf libglx-mesa0:armhf libgl1:armhf libgles2:armhf
 
-add_external_repo "box86" "https://Pi-Apps-Coders.github.io/box86-debs/debian ./" "https://pi-apps-coders.github.io/box86-debs/KEY.gpg" || exit 1
+add_external_repo "box86" "https://pi-apps-coders.github.io/box86-debs/KEY.gpg" "https://Pi-Apps-Coders.github.io/box86-debs/debian" "./" || exit 1
 
 apt_update
 if [ $? != 0 ]; then

--- a/apps/Box86/install-64
+++ b/apps/Box86/install-64
@@ -80,19 +80,12 @@ install_packages libc6:armhf libstdc++6:armhf \
   libgssapi-krb5-2:armhf libkrb5-3:armhf \
   $rpi_arm_userspace $mesa_va_drivers libegl1:armhf libglx-mesa0:armhf libgl1:armhf libgles2:armhf
 
-sudo wget https://pi-apps-coders.github.io/box86-debs/box86.list -O /etc/apt/sources.list.d/box86.list
-if [ $? != 0 ];then
-  sudo rm -f /etc/apt/sources.list.d/box86.list
-  error "Failed to add box86.list file!"
-fi
+add_external_repo "box86" "https://Pi-Apps-Coders.github.io/box86-debs/debian ./" "https://pi-apps-coders.github.io/box86-debs/KEY.gpg" || exit 1
 
-sudo rm -f /usr/share/keyrings/box86-debs-archive-keyring.gpg /etc/apt/trusted.gpg.d/box86-debs-archive-keyring.gpg
-sudo mkdir -p /etc/apt/trusted.gpg.d
-wget -qO- https://pi-apps-coders.github.io/box86-debs/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box86-debs-archive-keyring.gpg > /dev/null
-
-if [ $? != 0 ];then
-  sudo rm -f /etc/apt/sources.list.d/box86.list
-  error "Failed to add KEY.gpg to APT keyring!"
+apt_update
+if [ $? != 0 ]; then
+  rm_external_repo "box86"
+  error "Failed to perform apt update after adding box86 repository."
 fi
 
 # obtain SOC_ID

--- a/apps/Box86/uninstall
+++ b/apps/Box86/uninstall
@@ -9,9 +9,10 @@ function check-armhf() {
 
 purge_packages || exit 1
 
-sudo rm -f /etc/apt/sources.list.d/box86.list || error "Failed to remove repo!"
+# remove deprecated key locations
+sudo rm -f /usr/share/keyrings/box86-debs-archive-keyring.gpg /etc/apt/trusted.gpg.d/box86-debs-archive-keyring.gpg
 
-sudo rm -f /usr/share/keyrings/box86-debs-archive-keyring.gpg /etc/apt/trusted.gpg.d/box86-debs-archive-keyring.gpg || error "Failed to remove GPG key!"
+rm_external_repo "box86"
 
 if [ "$arch" == 64 ]; then
   # remove armhf architecture if no packages from it are currently installed

--- a/apps/Intellij IDEA/uninstall
+++ b/apps/Intellij IDEA/uninstall
@@ -2,7 +2,7 @@
 
 purge_packages || exit 1
 
-remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list
+rm_external_repo "adoptium"
   
 sudo rm -rf /opt/ideaIC /usr/share/applications/intellijidea.desktop
 # cleanup files leftover from potential failed install

--- a/apps/Minecraft Java Prism Launcher/uninstall
+++ b/apps/Minecraft Java Prism Launcher/uninstall
@@ -2,4 +2,4 @@
 
 purge_packages || exit 1
 
-remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list
+rm_external_repo "adoptium"

--- a/apps/Minecraft Java Server/uninstall
+++ b/apps/Minecraft Java Server/uninstall
@@ -16,7 +16,7 @@ if [[ "$1" != "update" ]];then
     sudo systemctl daemon-reload
     
     purge_packages || error "Dependencies failed to uninstall"
-    remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list
+    rm_external_repo "adoptium"
     remove_repofile_if_unused /etc/apt/sources.list.d/adoptopenjdk.list
 else
     echo "Uninstall skipped because run from the updater"

--- a/apps/Pale Moon/install-64
+++ b/apps/Pale Moon/install-64
@@ -3,7 +3,7 @@
 #remove deprecated files
 sudo rm -f /etc/apt/sources.list.d/home:stevenpusser.list /etc/apt/trusted.gpg.d/home_stevenpusser.gpg
 
-add_external_repo "stevenpusser" "http://download.opensuse.org/repositories/home:/stevenpusser/Debian_10/ /" "https://download.opensuse.org/repositories/home:stevenpusser/Debian_10/Release.key" || exit 1
+add_external_repo "stevenpusser" "https://download.opensuse.org/repositories/home:stevenpusser/Debian_10/Release.key" "http://download.opensuse.org/repositories/home:/stevenpusser/Debian_10/" "/" || exit 1
 
 apt_update
 if [ $? != 0 ]; then

--- a/apps/Pale Moon/install-64
+++ b/apps/Pale Moon/install-64
@@ -1,10 +1,14 @@
 #!/bin/bash
-echo 'deb http://download.opensuse.org/repositories/home:/stevenpusser/Debian_10/ /' | sudo tee /etc/apt/sources.list.d/home:stevenpusser.list >/dev/null
-curl -fsSL https://download.opensuse.org/repositories/home:stevenpusser/Debian_10/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_stevenpusser.gpg >/dev/null
 
-(install_packages palemoon)
-if [ $? != 0 ];then
-  #if package-installation failed, remove repository to avoid breaking apt updates
-  sudo rm -f /etc/apt/sources.list.d/home:stevenpusser.list /etc/apt/trusted.gpg.d/home_stevenpusser.gpg
-  exit 1
+#remove deprecated files
+sudo rm -f /etc/apt/sources.list.d/home:stevenpusser.list /etc/apt/trusted.gpg.d/home_stevenpusser.gpg
+
+add_external_repo "stevenpusser" "http://download.opensuse.org/repositories/home:/stevenpusser/Debian_10/ /" "https://download.opensuse.org/repositories/home:stevenpusser/Debian_10/Release.key" || exit 1
+
+apt_update
+if [ $? != 0 ]; then
+  rm_external_repo "stevenpusser"
+  error "Failed to perform apt update after adding stevenpusser repository."
 fi
+
+install_packages palemoon || exit 1

--- a/apps/Pale Moon/uninstall
+++ b/apps/Pale Moon/uninstall
@@ -1,4 +1,8 @@
 #!/bin/bash
 
 purge_packages || exit 1
-remove_repofile_if_unused /etc/apt/sources.list.d/home:stevenpusser.list
+
+#remove deprecated files
+sudo rm -f /etc/apt/sources.list.d/home:stevenpusser.list /etc/apt/trusted.gpg.d/home_stevenpusser.gpg
+
+rm_external_repo "stevenpusser"

--- a/apps/Pycharm CE/uninstall
+++ b/apps/Pycharm CE/uninstall
@@ -2,7 +2,7 @@
 
 purge_packages || exit 1
 
-remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list
+rm_external_repo "adoptium"
 
 echo "Deleting /opt/pycharm-community directory"
 sudo rm -rf /opt/pycharm-community || error "Failed to delete /opt/pycharm-community directory"

--- a/apps/Shattered Pixel Dungeon/uninstall
+++ b/apps/Shattered Pixel Dungeon/uninstall
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 purge_packages || exit 1
-remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list
+rm_external_repo "adoptium"
 
 rm -f ~/.local/share/applications/shatteredpd.desktop ~/.local/bin/ShatteredPD-Desktop.jar

--- a/apps/Sublime Text/install-64
+++ b/apps/Sublime Text/install-64
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-status "Adding GPG key..."
-wget -qO- https://download.sublimetext.com/sublimehq-pub.gpg | sudo tee /etc/apt/trusted.gpg.d/sublimehq.asc || error "Failed to add GPG key for sublime-text repository!"
-echo "deb https://download.sublimetext.com/ apt/stable/" | sudo tee /etc/apt/sources.list.d/sublime-text.list
+#remove deprecated files
+sudo rm -f /etc/apt/trusted.gpg.d/sublimehq.asc /etc/apt/sources.list.d/sublime-text.list
 
-(install_packages sublime-text)
-if [ $? != 0 ];then
-  #if install_packages fails, remove repository
-  sudo rm -f /etc/apt/sources.list.d/sublime-text.list
-  exit 1
+add_external_repo "sublimehq" "https://download.sublimetext.com/ apt/stable/" "https://download.sublimetext.com/sublimehq-pub.gpg" || exit 1
+
+apt_update
+if [ $? != 0 ]; then
+  rm_external_repo "sublimehq"
+  error "Failed to perform apt update after adding sublimehq repository."
 fi
+
+install_packages sublime-text || exit 1

--- a/apps/Sublime Text/install-64
+++ b/apps/Sublime Text/install-64
@@ -3,7 +3,7 @@
 #remove deprecated files
 sudo rm -f /etc/apt/trusted.gpg.d/sublimehq.asc /etc/apt/sources.list.d/sublime-text.list
 
-add_external_repo "sublimehq" "https://download.sublimetext.com/ apt/stable/" "https://download.sublimetext.com/sublimehq-pub.gpg" || exit 1
+add_external_repo "sublimehq" "https://download.sublimetext.com/sublimehq-pub.gpg" "https://download.sublimetext.com/" "apt/stable/" || exit 1
 
 apt_update
 if [ $? != 0 ]; then

--- a/apps/Sublime Text/uninstall
+++ b/apps/Sublime Text/uninstall
@@ -3,4 +3,8 @@
 rm -f ~/.local/share/applications/sublime-text.desktop
 rm -rf ~/"Sublime Text 2"
 purge_packages || exit 1
-remove_repofile_if_unused /etc/apt/sources.list.d/sublime-text.list
+
+#remove deprecated files
+sudo rm -f /etc/apt/trusted.gpg.d/sublimehq.asc /etc/apt/sources.list.d/sublime-text.list
+
+rm_external_repo "sublimehq"

--- a/apps/Unciv/uninstall
+++ b/apps/Unciv/uninstall
@@ -6,7 +6,7 @@ if [[ "$1" != "update" ]]; then
 
   purge_packages || exit 1
 
-  remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list
+  rm_external_repo "adoptium"
 else
   echo "Uninstall skipped because run from the updater"
 fi

--- a/apps/WorldPainter/uninstall
+++ b/apps/WorldPainter/uninstall
@@ -3,4 +3,4 @@
 sudo rm -f /opt/worldpainter/.install4j/pref_jre.cfg
 
 purge_packages || exit 1
-remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list
+rm_external_repo "adoptium"

--- a/apps/Xtreme Download Manager/uninstall
+++ b/apps/Xtreme Download Manager/uninstall
@@ -1,6 +1,6 @@
 #!/bin/bash
 purge_packages || exit 1
-remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list
+rm_external_repo "adoptium"
 
 sudo rm -rf /opt/xdman || error "Failed to remove /opt/xdman/ directpry!"
 sudo rm -f /usr/share/applications/xdman.desktop || error "Failed to remove menu shortcut!"

--- a/apps/jGRASP IDE/uninstall
+++ b/apps/jGRASP IDE/uninstall
@@ -3,4 +3,4 @@ rm -rf ~/jgrasp.zip ~/jgrasp
 
 
 purge_packages || exit 1
-remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list
+rm_external_repo "adoptium"


### PR DESCRIPTION
As suggested in https://github.com/Botspot/pi-apps/pull/1889, this is a function that adds external apt repositories when provided:

- an external repo path (such as `https://ryanfortner.github.io/box64-debs/debian ./`) 
- a repo name (such as `box64`)
- a url to the repo's gpg pubkey (such as `https://ryanfortner.github.io/box64-debs/KEY.gpg`)

Example of the usage of these functions:
```bash
add_external_repo "https://ryanfortner.github.io/box64-debs/debian ./" "box64" "https://ryanfortner.github.io/box64-debs/KEY.gpg" || exit 1

rm_external_repo "box64" || exit 1 # this will remove the repo if nothing is used in it
rm_external_repo "box64" "force" || exit 1 # this will remove the repo even if software is installed from it
```

This is my first try at creating a function for pi-apps and I would appreciate any feedback I receive!