### PR TITLE
switch to Davidk prusaslicer builds

### DIFF
--- a/.github/workflows/updates/PrusaSlicer.sh
+++ b/.github/workflows/updates/PrusaSlicer.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+webVer=$(get_release davidk/PrusaSlicer-ARM.AppImage | tr -d "version_")
+armhf_url="https://github.com/davidk/PrusaSlicer-ARM.AppImage/releases/download/version_${webVer}/PrusaSlicer-version_${webVer}-armhf.AppImage"
+arm64_url="https://github.com/davidk/PrusaSlicer-ARM.AppImage/releases/download/version_${webVer}/PrusaSlicer-version_${webVer}-aarch64.AppImage"
+
+source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh

--- a/apps/PrusaSlicer/description
+++ b/apps/PrusaSlicer/description
@@ -1,1 +1,3 @@
 Takes a 3D model and slices it for use in a 3D printer.
+To run: Menu -> Programming -> PrusaSlicer
+To run in a terminal: ~/PrusaSlicer.AppImage

--- a/apps/PrusaSlicer/install-32
+++ b/apps/PrusaSlicer/install-32
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+version=2.4.2
+
 install_packages git cmake libboost-dev libboost-regex-dev libboost-filesystem-dev libboost-thread-dev libboost-log-dev libboost-locale-dev libcurl4-openssl-dev build-essential pkg-config libtbb-dev zlib1g-dev libcereal-dev libeigen3-dev libnlopt-cxx-dev libudev-dev libopenvdb-dev libboost-iostreams-dev libnlopt-dev libdbus-1-dev || exit 1
 
-wget 'https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.4.0/PrusaSlicer-2.4.0+linux-armv7l-202112220001.AppImage' -O ~/PrusaSlicer.AppImage || error "Failed to download appimage!"
+wget "https://github.com/davidk/PrusaSlicer-ARM.AppImage/releases/download/version_${version}/PrusaSlicer-version_${version}-armhf.AppImage" -O ~/PrusaSlicer.AppImage || error "Failed to download appimage!"
 chmod +x ~/PrusaSlicer.AppImage || error "Failed to mark as executable!"
 
 mkdir -p ~/prusa-slicer

--- a/apps/PrusaSlicer/install-64
+++ b/apps/PrusaSlicer/install-64
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+version=2.4.2
+
 install_packages git cmake libboost-dev libboost-regex-dev libboost-filesystem-dev libboost-thread-dev libboost-log-dev libboost-locale-dev libcurl4-openssl-dev libwxgtk3.0-gtk3-dev build-essential pkg-config libtbb-dev zlib1g-dev libcereal-dev libeigen3-dev libnlopt-cxx-dev libudev-dev libopenvdb-dev libboost-iostreams-dev libnlopt-dev libdbus-1-dev || exit 1
 
-wget 'https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.4.0/PrusaSlicer-2.4.0+linux-aarch64-GTK3-202112212031.AppImage' -O ~/PrusaSlicer.AppImage || error "Failed to download appimage!"
+wget "https://github.com/davidk/PrusaSlicer-ARM.AppImage/releases/download/version_${version}/PrusaSlicer-version_${version}-aarch64.AppImage" -O ~/PrusaSlicer.AppImage || error "Failed to download appimage!"
 chmod +x ~/PrusaSlicer.AppImage || error "Failed to mark as executable!"
 
 mkdir -p ~/prusa-slicer


### PR DESCRIPTION
upstream prusaslicer has stopped producing ARM64 appimages for versions after 2.4.0. Upstream appimages were also not compatible on bionic, while the builds from davidk are. davidk continues to produce both armhf and arm64 appimages on the latest release.