### PR TITLE
regenerate yad list if has one form of corruption

### DIFF
--- a/preload
+++ b/preload
@@ -111,6 +111,18 @@ fi
 if [ ! -f "$listfile" ] || [ -z "$(cat "$listfile")" ];then
   echo "list file for $prefix does not exist." 1>&2
   reloadlist=1
+else
+  list_lenght=$(wc -l "$listfile" | awk '{print $1}')
+fi
+
+if [ -n "$list_lenght" ] && [ "$format" == yad ] && (( $list_lenght % 5 )) ; then
+  echo "yad lists are a multiple of 5, $prefix does not have a list a multiple of 5 so it may be corrupted and needs regenerating." 1>&2
+  reloadlist=1
+fi
+
+if [ ! -f "$listfile" ] || [ -z "$(cat "$listfile")" ];then
+  echo "list file for $prefix does not exist." 1>&2
+  reloadlist=1
 fi
 
 #If updates available, show special Updates category (returned separately to avoid re-preloading after update-check finishes)


### PR DESCRIPTION
we have seen a couple of cases (as have I myself) where a yad list gets corrupted (probably by us writing to it twice at once).

this adds a simple check for a yad list to verify it is a multiple of 5. if it is not, then regenerate it.