### PR TITLE
preload bugfixes and optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ update
 etc/genapplist-yad
 data
 logs
-icons/vector/splashscreen.svg
-icons/splashscreen.png

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -224,13 +224,6 @@ Note: new functions are added often. If you don't see a function on this list bu
   - This function outputs to `stderr`.
 - `generate_logo` - Displays the Pi-Apps logo in a terminal.
   - Note: Some keen users may notice that the logo looks different on Debian ***Bullseye*** than on older releases. This is necessary to avoid trying to display missing characters. See: https://github.com/Botspot/pi-apps/issues/1441
-- `generate_splashscreen` - When Pi-Apps launches, it displays a splashscreen for a few moments while it loads. Each time you see it, new app-icons are placed in the 10 locations. This function is responsible for doing that.
-    The method for doing this is fairly straightforward:
-  - First, a vector image is created and images are embedded in it. (In this case, Botspot made the original image with Boxy SVG)
-  - Vector images are simply text-files. They store binary data by encoding it with `base64`.
-  - To replace an embedded image, use a text-editor to replace the existing base64-data with new base64-data from your desired PNG image.
-  - This function does exactly that - it takes `icons/vector/splashscreen-original.svg`, uses `sed` to insert 10 random app-icons, saves the resulting image to `icons/vector/splashscreen.svg`, and then converts that image to PNG and saves it to `icons/splashscreen.png`.
-  - For more details, see: https://github.com/Botspot/pi-apps/issues/1299
 - `add_english` - Ensures an English locale is installed so that log-diagnosing tools can function properly.
   - This was added in [PR #1031](https://github.com/Botspot/pi-apps/pull/1031)
 
@@ -542,15 +535,14 @@ To start Pi-Apps on a specific category:
 ~/pi-apps/gui 'All Apps/'
 ```
 #### How it works:
-1. The splash screen appears.
-2. The `api` script is sourced.
-3. The pi-apps logo is displayed in the terminal (using the `generate_logo` function)
-4. A series of `runonce` entries are executed in the background.
-5. The message of the day is determined.
+1. The `api` script is sourced.
+2. The pi-apps logo is displayed in the terminal (using the `generate_logo` function)
+3. A series of `runonce` entries are executed in the background.
+4. The message of the day is determined.
     - To save time, it's stored in `data/announcements`.
     - If that file is missing or it's more than a day old, it is downloaded from [the pi-apps-announcements repository](https://github.com/Botspot/pi-apps-announcements).
     - One random line is taken from the file and used as the message for this session.
-6. We now come to a `while` loop that runs the GUI. Inside is an `if` statement that obeys the following values of the `$action` variable:
+5. We now come to a `while` loop that runs the GUI. Inside is an `if` statement that obeys the following values of the `$action` variable:
     - `main-window` - Handles the app list.
       - This may be a yad window or an xlunch window, depending on the "App List Style" setting.
       - Xlunch is compiled, if necessary.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ wget -qO- https://raw.githubusercontent.com/Botspot/pi-apps/master/install | bas
 #### Supported systems:
 
 - [Raspberry Pi OS](https://www.raspberrypi.com/software/operating-systems/) (32-bit/64-bit) (Buster/Bullseye): fully supported.
-- [Twister OS](https://twisteros.com/download.html): fully supported, preinstalled.
 - Kali Linux, Ubuntu, Ubuntu Mate, any other Debian-based ARM OS: Pi-Apps should mostly work but you may encounter errors for some apps.
 - Android, ChromeOS, non-ARM, non-Debian operating systems: Not supported. Your mileage may vary.
 

--- a/api
+++ b/api
@@ -1766,11 +1766,11 @@ send_error_report() { #non-interactively send a Pi-Apps error log file to the Bo
 runonce() { #run command only if it's never been run before. Useful for one-time migration or setting changes.
   #Runs a script in the form of stdin
   
-  script="$(cat /dev/stdin)"
+  script="$(< /dev/stdin)"
   
   runonce_hash="$(sha1sum <<<"$script" | awk '{print $1}')"
   
-  if grep -qxF "$runonce_hash" "${DIRECTORY}/data/runonce_hashes" ;then
+  if [ -s "${DIRECTORY}/data/runonce_hashes" ] && while read line; do [[ $line == "$runonce_hash" ]] && break; done < "${DIRECTORY}/data/runonce_hashes"; then
     #hash found
     #echo "runonce: '$script' already run before. Skipping."
     true

--- a/api
+++ b/api
@@ -1765,10 +1765,8 @@ send_error_report() { #non-interactively send a Pi-Apps error log file to the Bo
 #miscellaneous low-level functions below
 runonce() { #run command only if it's never been run before. Useful for one-time migration or setting changes.
   #Runs a script in the form of stdin
-  
-  script="$(< /dev/stdin)"
-  
-  runonce_hash="$(sha1sum <<<"$script" | awk '{print $1}')"
+    
+  runonce_hash="$(sha1sum <<<"$(< /dev/stdin)" | awk '{print $1}')"
   
   if [ -s "${DIRECTORY}/data/runonce_hashes" ] && while read line; do [[ $line == "$runonce_hash" ]] && break; done < "${DIRECTORY}/data/runonce_hashes"; then
     #hash found
@@ -1776,13 +1774,13 @@ runonce() { #run command only if it's never been run before. Useful for one-time
     true
   else
     #run the script.
-    bash <(echo "$script")
+    bash <(echo "$(< /dev/stdin)")
     #if it succeeds, add the hash to the list to never run it again
     if [ $? == 0 ];then
       echo "$runonce_hash" >> "${DIRECTORY}/data/runonce_hashes"
-      echo "runonce(): '$script' succeeded. Added to list."
+      echo "runonce(): '$(< /dev/stdin)' succeeded. Added to list."
     else
-      echo "runonce(): '$script' failed. Not adding hash to list."
+      echo "runonce(): '$(< /dev/stdin)' failed. Not adding hash to list."
     fi
     
   fi

--- a/api
+++ b/api
@@ -777,7 +777,7 @@ read_category_files() { #Generates a combined categories-list from several sourc
   (cat "${DIRECTORY}/data/category-overrides" "${DIRECTORY}/etc/categories" ; echo ; list_apps local | sed 's/$/|/g') | awk -F'|' '!seen[$1]++' | grep .
 }
 
-app_prefix_category() { #lists all apps in a virtual filesystem based on categories file. Format: "category/app"
+app_prefix_category() { #lists all apps in a category with formast "category/app", or if $1 is left blank, then list the full structure of all categories
   
   #Subtract a type of app if enabled
   local show_apps_setting="$(cat "${DIRECTORY}/data/settings/Show apps")"

--- a/api
+++ b/api
@@ -1991,6 +1991,7 @@ $(head -n1 "${DIRECTORY}/apps/$app/description")"
     
   fi
 }
+#end of miscellaneous low-level functions
 
 #command interceptors - functions that enhance a command
 enable_module() { #Permanent equivalent to modprobe, this will load the module on every future startup

--- a/api
+++ b/api
@@ -777,37 +777,6 @@ read_category_files() { #Generates a combined categories-list from several sourc
   (cat "${DIRECTORY}/data/category-overrides" "${DIRECTORY}/etc/categories" ; echo ; list_apps local | sed 's/$/|/g') | awk -F'|' '!seen[$1]++' | grep .
 }
 
-app_categories() { #lists all apps in a virtual filesystem based on categories file. Format: "category/app"
-  
-  #Subtract a type of app if enabled
-  local show_apps_setting="$(cat "${DIRECTORY}/data/settings/Show apps")"
-  local filter=()
-  if [ "$show_apps_setting" == 'standard' ];then
-    #if only showing standard apps, hide package apps
-    filter=(list_subtract "$(list_apps package | sed 's+^+.*/+g')")
-  elif [ "$show_apps_setting" == 'packages' ];then
-    #if only showing package apps, hide standard apps
-    filter=(list_subtract "$(list_apps standard | sed 's+^+.*/+g')")
-  else
-    #is the setting is "all" or missing, don't filter.
-    filter=(cat)
-  fi
-  
-  #show normal categories
-  read_category_files | grep . | awk -F'|' '{print $2"/"$1}' | sed 's+^/++g' | "${filter[@]}"
-  
-  #show special "Installed" category - don't filter it
-  list_apps installed | sed 's+^+Installed/+g'
-  
-  #show special "Packages" category
-  if [ "$show_apps_setting" != standard ];then
-    list_apps package | list_subtract "$(list_apps hidden)" | sed 's+^+Packages/+g'
-  fi
-  
-  #show special "All Apps" category
-  list_apps cpu_installable | list_subtract "$(list_apps hidden)" | sed 's+^+All Apps/+g' | "${filter[@]}"
-}
-
 app_prefix_category() { #lists all apps in a virtual filesystem based on categories file. Format: "category/app"
   
   #Subtract a type of app if enabled
@@ -832,6 +801,20 @@ app_prefix_category() { #lists all apps in a virtual filesystem based on categor
     list_apps package | list_subtract "$(list_apps hidden)" | sed 's+^+Packages/+g'
   #show special "All Apps" category
   elif [ "$1" == "All Apps" ]; then
+    list_apps cpu_installable | list_subtract "$(list_apps hidden)" | sed 's+^+All Apps/+g' | "${filter[@]}"
+  # show all categories
+  elif [ "$1" == "" ]; then
+    #show normal categories
+    read_category_files | grep . | awk -F'|' '{print $2"/"$1}' | sed 's+^/++g' | "${filter[@]}"
+    
+    #show special "Installed" category - don't filter it
+    list_apps installed | sed 's+^+Installed/+g'
+    
+    #show special "Packages" category
+    if [ "$show_apps_setting" != standard ];then
+      list_apps package | list_subtract "$(list_apps hidden)" | sed 's+^+Packages/+g'
+    fi
+    #show special "All Apps" category
     list_apps cpu_installable | list_subtract "$(list_apps hidden)" | sed 's+^+All Apps/+g' | "${filter[@]}"
   #show normal categories
   else

--- a/api
+++ b/api
@@ -803,7 +803,7 @@ app_prefix_category() { #lists all apps in a category with formast "category/app
   elif [ "$1" == "All Apps" ]; then
     list_apps cpu_installable | list_subtract "$(list_apps hidden)" | sed 's+^+All Apps/+g' | "${filter[@]}"
   # show all categories
-  elif [ "$1" == "" ]; then
+  elif [ -z "$1" ];; then
     #show normal categories
     read_category_files | grep . | awk -F'|' '{print $2"/"$1}' | sed 's+^/++g' | "${filter[@]}"
     

--- a/api
+++ b/api
@@ -767,14 +767,14 @@ read_category_files() { #Generates a combined categories-list from several sourc
   #remove app category if app folder not found
   local IFS=$'\n'
   local app
-  for app in $(cat "${DIRECTORY}/data/category-overrides"); do 
+  for app in $(cat "${DIRECTORY}/data/category-overrides" 2>/dev/null); do
     if ! [ -d "${DIRECTORY}/apps/$(echo "$app" | sed 's/|.*//')" ] &>/dev/null; then 
       sed -i "/$app/d"  "${DIRECTORY}/data/category-overrides"
     fi
   done
   
   #list the user-overrides file              and the global categories file          |-----and all apps------------|     filter out duplicates   no '\n\n'
-  (cat "${DIRECTORY}/data/category-overrides" "${DIRECTORY}/etc/categories" ; echo ; list_apps local | sed 's/$/|/g') | awk -F'|' '!seen[$1]++' | grep .
+  (cat "${DIRECTORY}/data/category-overrides" "${DIRECTORY}/etc/categories" 2>/dev/null ; echo ; list_apps local | sed 's/$/|/g') | awk -F'|' '!seen[$1]++' | grep .
 }
 
 app_prefix_category() { #lists all apps in a category with format "category/app", or if $1 is left blank, then list the full structure of all categories

--- a/api
+++ b/api
@@ -1098,13 +1098,8 @@ refresh_pkgapp_status() { #for the specified package-app, if dpkg thinks it's in
       bitly_link "$app" uninstall &
     fi
   else
-    #this app is trying to install a package that's not on the repository. Hide the app.
-    #only mark as hidden if its not already marked as hidden, this prevents changing the timestamp of the file, causing the preload script to re-load
-    #a common issue on All-Apps
-    if ! grep -Fxq "$app|hidden" "${DIRECTORY}/data/category-overrides" ;then
-      echo "Marking $app as hidden"
-      "${DIRECTORY}/etc/categoryedit" "$app" 'hidden' >/dev/null
-    fi
+    echo "Marking $app as hidden"
+    "${DIRECTORY}/etc/categoryedit" "$app" 'hidden' >/dev/null
   fi
 }
 

--- a/api
+++ b/api
@@ -777,7 +777,7 @@ read_category_files() { #Generates a combined categories-list from several sourc
   (cat "${DIRECTORY}/data/category-overrides" "${DIRECTORY}/etc/categories" ; echo ; list_apps local | sed 's/$/|/g') | awk -F'|' '!seen[$1]++' | grep .
 }
 
-app_prefix_category() { #lists all apps in a category with formast "category/app", or if $1 is left blank, then list the full structure of all categories
+app_prefix_category() { #lists all apps in a category with format "category/app", or if $1 is left blank, then list the full structure of all categories
   
   #Subtract a type of app if enabled
   local show_apps_setting="$(cat "${DIRECTORY}/data/settings/Show apps")"
@@ -1081,6 +1081,7 @@ refresh_pkgapp_status() { #for the specified package-app, if dpkg thinks it's in
       bitly_link "$app" uninstall &
     fi
   else
+    #this app is trying to install a package that's not on the repository. Hide the app.
     echo "Marking $app as hidden"
     "${DIRECTORY}/etc/categoryedit" "$app" 'hidden' >/dev/null
   fi

--- a/api
+++ b/api
@@ -1090,13 +1090,12 @@ refresh_pkgapp_status() { #for the specified package-app, if dpkg thinks it's in
 refresh_all_pkgapp_status() { #for every package-app, if dpkg thinks it's installed, then mark it as installed.
   #repeat for every package-type app
   local IFS=$'\n'
+  local PIDS=()
   for app in $(list_apps package) ;do
-    refresh_pkgapp_status "$app" &  declare PID_$(TMP=${app//-/_};echo ${TMP// /_})=$!
+    refresh_pkgapp_status "$app" &
+    PIDS+=("$!")
   done
-  for app in $(list_apps package) ;do
-    varname=PID_$(TMP=${app//-/_};echo ${TMP// /_})
-    wait $(echo ${!varname})
-  done
+  wait "${PIDS[@]}" #wait for all subprocesses to complete
 }
 
 refresh_app_list() { #Force-regenerate the app list

--- a/api
+++ b/api
@@ -1070,8 +1070,12 @@ refresh_pkgapp_status() { #for the specified package-app, if dpkg thinks it's in
     fi
   else
     #this app is trying to install a package that's not on the repository. Hide the app.
-    echo "Marking $app as hidden"
-    "${DIRECTORY}/etc/categoryedit" "$app" 'hidden' >/dev/null
+    #only mark as hidden if its not already marked as hidden, this prevents changing the timestamp of the file, causing the preload script to re-load
+    #a common issue on All-Apps
+    if ! grep -Fxq "$app|hidden" "${DIRECTORY}/data/category-overrides" ;then
+      echo "Marking $app as hidden"
+      "${DIRECTORY}/etc/categoryedit" "$app" 'hidden' >/dev/null
+    fi
   fi
 }
 

--- a/api
+++ b/api
@@ -1091,7 +1091,11 @@ refresh_all_pkgapp_status() { #for every package-app, if dpkg thinks it's instal
   #repeat for every package-type app
   local IFS=$'\n'
   for app in $(list_apps package) ;do
-    refresh_pkgapp_status "$app"
+    refresh_pkgapp_status "$app" &  declare PID_$(TMP=${app//-/_};echo ${TMP// /_})=$!
+  done
+  for app in $(list_apps package) ;do
+    varname=PID_$(TMP=${app//-/_};echo ${TMP// /_})
+    wait $(echo ${!varname})
   done
 }
 

--- a/api
+++ b/api
@@ -1731,8 +1731,10 @@ send_error_report() { #non-interactively send a Pi-Apps error log file to the Bo
 #miscellaneous low-level functions below
 runonce() { #run command only if it's never been run before. Useful for one-time migration or setting changes.
   #Runs a script in the form of stdin
-    
-  runonce_hash="$(sha1sum <<<"$(< /dev/stdin)" | awk '{print $1}')"
+  
+  script="$(< /dev/stdin)"
+  
+  runonce_hash="$(sha1sum <<<"$script" | awk '{print $1}')"
   
   if [ -s "${DIRECTORY}/data/runonce_hashes" ] && while read line; do [[ $line == "$runonce_hash" ]] && break; done < "${DIRECTORY}/data/runonce_hashes"; then
     #hash found
@@ -1740,13 +1742,13 @@ runonce() { #run command only if it's never been run before. Useful for one-time
     true
   else
     #run the script.
-    bash <(echo "$(< /dev/stdin)")
+    bash <(echo "$script")
     #if it succeeds, add the hash to the list to never run it again
     if [ $? == 0 ];then
       echo "$runonce_hash" >> "${DIRECTORY}/data/runonce_hashes"
-      echo "runonce(): '$(< /dev/stdin)' succeeded. Added to list."
+      echo "runonce(): '$script' succeeded. Added to list."
     else
-      echo "runonce(): '$(< /dev/stdin)' failed. Not adding hash to list."
+      echo "runonce(): '$script' failed. Not adding hash to list."
     fi
     
   fi

--- a/api
+++ b/api
@@ -57,40 +57,6 @@ generate_logo() { #display colorized Pi-Apps logo in terminal
 \e[0m\e[0m"
   fi
 }
-
-generate_splashscreen() { #Place 10 random app icons on the loading screen for the next time Pi-Apps launches
-  
-  #get 10 random apps. Some are exempted because they don't display well.
-  local apps="$(list_apps local | grep -v 'Raspi2png\|template\|YouTubuddy' | shuf)"
-  
-  local app1="$(sed -n 1p <<<"$apps")"
-  local app2="$(sed -n 2p <<<"$apps")"
-  local app3="$(sed -n 3p <<<"$apps")"
-  local app4="$(sed -n 4p <<<"$apps")"
-  local app5="$(sed -n 5p <<<"$apps")"
-  local app6="$(sed -n 6p <<<"$apps")"
-  local app7="$(sed -n 7p <<<"$apps")"
-  local app8="$(sed -n 8p <<<"$apps")"
-  local app9="$(sed -n 9p <<<"$apps")"
-  local app10="$(sed -n 10p <<<"$apps")"
-  
-  #display the chosen apps
-  #echo "$apps" | head -n 10
-  
-  sed "s_IMAGE0_$(base64 "${DIRECTORY}/apps/${app1}/icon-64.png" -w 0)_g ; \
-  s_IMAGE1_$(base64 "${DIRECTORY}/apps/${app2}/icon-64.png" -w 0)_g ; \
-  s_IMAGE2_$(base64 "${DIRECTORY}/apps/${app3}/icon-64.png" -w 0)_g ; \
-  s_IMAGE3_$(base64 "${DIRECTORY}/apps/${app4}/icon-64.png" -w 0)_g ; \
-  s_IMAGE4_$(base64 "${DIRECTORY}/apps/${app5}/icon-64.png" -w 0)_g ; \
-  s_IMAGE5_$(base64 "${DIRECTORY}/apps/${app6}/icon-64.png" -w 0)_g ; \
-  s_IMAGE6_$(base64 "${DIRECTORY}/apps/${app7}/icon-64.png" -w 0)_g ; \
-  s_IMAGE7_$(base64 "${DIRECTORY}/apps/${app8}/icon-64.png" -w 0)_g ; \
-  s_IMAGE8_$(base64 "${DIRECTORY}/apps/${app9}/icon-64.png" -w 0)_g ; \
-  s_IMAGE9_$(base64 "${DIRECTORY}/apps/${app10}/icon-64.png" -w 0)_g" "${DIRECTORY}/icons/vector/splashscreen-original.svg" > "${DIRECTORY}/icons/vector/splashscreen.svg"
-  
-  rsvg-convert "${DIRECTORY}/icons/vector/splashscreen.svg" > "${DIRECTORY}/icons/splashscreen.png" || rm -rf "${DIRECTORY}/icons/splashscreen.png"
-  
-}
 #end of output functions
 
 add_english() { #add en_US locale for more accurate error

--- a/api
+++ b/api
@@ -1991,7 +1991,6 @@ $(head -n1 "${DIRECTORY}/apps/$app/description")"
     
   fi
 }
-#end of miscellaneous low-level functions
 
 #command interceptors - functions that enhance a command
 enable_module() { #Permanent equivalent to modprobe, this will load the module on every future startup

--- a/api
+++ b/api
@@ -122,10 +122,10 @@ package_installed() { #exit 0 if $1 package is installed, otherwise exit 1
   local package="$1"
   [ -z "$package" ] && error "package_installed(): no package specified!"
   #find the package listed in /var/lib/dpkg/status
-  #package_info "$package" | grep -q '^Status: install ok installed$'
+  #package_info "$package"
   
   #directly search /var/lib/dpkg/status
-  grep '^Status: install ok installed$\|^Package:' /var/lib/dpkg/status | grep -xF "Package: $package" --after 1 | grep -q 'Status: install ok installed'
+  grep "^Package: $package$" /var/lib/dpkg/status -A 1 | tail -n 1 | grep -q 'Status: install ok installed'
 }
 
 package_available() { #determine if the specified package-name exists in a repository

--- a/api
+++ b/api
@@ -755,13 +755,11 @@ list_apps() { # $1 can be: installed, uninstalled, corrupted, cpu_installable, h
 }
 
 list_intersect() { #Outputs only the apps that appear in both stdin and in $1
-  #                      change \n to \|     |   remove last "\|"
-  grep -x "$(echo "$1" | sed -z 's/\n/\\|/g' | sed -z 's/\\|$/\n/g')"
+  comm -12 - <(echo "$1" | sort)
 }
 
 list_subtract() { #Outputs a list of apps from stdin, minus the ones that appear in $1
-  #                       change \n to \|     |   remove last "\|"
-  grep -vx "$(echo "$1" | sed -z 's/\n/\\|/g' | sed -z 's/\\|$/\n/g')"
+  comm -23 - <(echo "$1" | sort)
 }
 
 read_category_files() { #Generates a combined categories-list from several sources: category-overrides, global categories file, and unlisted apps. Format: "app|category"

--- a/api
+++ b/api
@@ -803,7 +803,7 @@ app_prefix_category() { #lists all apps in a category with formast "category/app
   elif [ "$1" == "All Apps" ]; then
     list_apps cpu_installable | list_subtract "$(list_apps hidden)" | sed 's+^+All Apps/+g' | "${filter[@]}"
   # show all categories
-  elif [ -z "$1" ];; then
+  elif [ -z "$1" ]; then
     #show normal categories
     read_category_files | grep . | awk -F'|' '{print $2"/"$1}' | sed 's+^/++g' | "${filter[@]}"
     

--- a/api
+++ b/api
@@ -810,6 +810,37 @@ app_categories() { #lists all apps in a virtual filesystem based on categories f
   list_apps cpu_installable | list_subtract "$(list_apps hidden)" | sed 's+^+All Apps/+g' | "${filter[@]}"
 }
 
+app_prefix_category() { #lists all apps in a virtual filesystem based on categories file. Format: "category/app"
+  
+  #Subtract a type of app if enabled
+  local show_apps_setting="$(cat "${DIRECTORY}/data/settings/Show apps")"
+  local filter=()
+  if [ "$show_apps_setting" == 'standard' ];then
+    #if only showing standard apps, hide package apps
+    filter=(list_subtract "$(list_apps package | sed 's+^+.*/+g')")
+  elif [ "$show_apps_setting" == 'packages' ];then
+    #if only showing package apps, hide standard apps
+    filter=(list_subtract "$(list_apps standard | sed 's+^+.*/+g')")
+  else
+    #is the setting is "all" or missing, don't filter.
+    filter=(cat)
+  fi
+  
+  #show special "Installed" category - don't filter it
+  if [ "$1" == "Installed" ]; then
+    list_apps installed | sed 's+^+Installed/+g'
+  #show special "Packages" category
+  elif [ "$1" == "Packages" ]; then
+    list_apps package | list_subtract "$(list_apps hidden)" | sed 's+^+Packages/+g'
+  #show special "All Apps" category
+  elif [ "$1" == "All Apps" ]; then
+    list_apps cpu_installable | list_subtract "$(list_apps hidden)" | sed 's+^+All Apps/+g' | "${filter[@]}"
+  #show normal categories
+  else
+    read_category_files | grep . | awk -F'|' '{print $2"/"$1}' | grep "^$1/" | sed 's+^/++g' | "${filter[@]}"
+  fi
+}
+
 bitly_link() { #Runs whenever an app is installed/uninstalled to tally the number of users for each app
   #This cannot possibly be used to identify you, or any information about you.
   #It simply "clicks" a bitly link - a shortened URL - so that the total number of clicks can be tallied to determine how popular a certain app is.

--- a/api
+++ b/api
@@ -131,8 +131,8 @@ package_installed() { #exit 0 if $1 package is installed, otherwise exit 1
 package_available() { #determine if the specified package-name exists in a repository
   local package="$1"
   [ -z "$package" ] && error "package_available(): no package name specified!"
-  #using grep to do this is nearly instantaneous, rather than apt-cache which takes several seconds
-  grep -rqx "Package: $package" /var/lib/apt/lists --exclude="lock" --exclude-dir="partial" 2>/dev/null
+  #using find and grep to do this is nearly instantaneous, rather than apt-cache which takes several seconds
+  find /var/lib/apt/lists -maxdepth 1 -name "*_Packages" | xargs grep -q "^Package: $package$"
 }
 
 package_dependencies() { #outputs the list of dependencies for the $1 package

--- a/etc/categoryedit
+++ b/etc/categoryedit
@@ -12,17 +12,17 @@ function error {
 #Only one instance of this script should run at a time. wait if another process other than this one is running
 #skip this check if this instance does not have an ARG (running as a GUI)
 if [ ! -z "$1" ];then
-  # processes which are using categoryedit for scripting (not a GUI) will have additional column 4 and 5 output (the arguments)
-  # output of below command is: PID ARG1
-  # pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}'
+  # processes which are using categoryedit for scripting (not a GUI) will have additional column 3 and 4 output (the arguments)
+  # output of below command is: PID /bin/bash ARG1 ARG2
+  # pgrep categoryedit -a | sed -n "s:${DIRECTORY}/etc/categoryedit::p"
 
   # remove all output from the list if there is no second column (aka, there was not argument, meaning it is a GUI)
-  # pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}' | awk '$2 != ""'
+  # pgrep categoryedit -a | sed -n "s:${DIRECTORY}/etc/categoryedit::p" | awk '{print $1, $3}' | awk '$2 != ""'
 
   # now only print the first column (the PIDs)
-  # pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}' | awk '$2 != ""' | awk '{print $1}'
+  # pgrep categoryedit -a | sed -n "s:${DIRECTORY}/etc/categoryedit::p" | awk '{print $1, $3}' | awk '$2 != ""' | awk '{print $1}'
 
-  while [[ $(pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}' | awk '$2 != ""' | awk '{print $1}' | sort | head -n 1) != $$ ]]; do
+  while [[ $(pgrep categoryedit -a | sed -n "s:${DIRECTORY}/etc/categoryedit::p" | awk '{print $1, $3}' | awk '$2 != ""' | awk '{print $1}' | sort | head -n 1) != $$ ]]; do
     # waiting for another instance of categoryedit to finish
     sleep 0.02
   done

--- a/etc/categoryedit
+++ b/etc/categoryedit
@@ -1,12 +1,18 @@
 #!/bin/bash
-DIRECTORY="$(readlink -f "$(dirname "$(dirname "$0")")")"
+
+if [ -z "$DIRECTORY" ]; then
+  DIRECTORY="$(readlink -f "$(dirname "$(dirname "$0")")")"
+fi
 
 function error {
   echo -e "\e[91m$1\e[39m"
   exit 1
 }
 
-source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"
+#for read_category_files()
+if ! command -v read_category_files >/dev/null ;then
+  source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"
+fi
 
 refresh() { #set the categories variable to the current categories
   categories="$(read_category_files)"

--- a/etc/categoryedit
+++ b/etc/categoryedit
@@ -14,15 +14,15 @@ function error {
 if [ ! -z "$1" ];then
   # processes which are using categoryedit for scripting (not a GUI) will have additional column 3 and 4 output (the arguments)
   # output of below command is: PID /bin/bash ARG1 ARG2
-  # pgrep categoryedit -a | sed -n "s:${DIRECTORY}/etc/categoryedit::p"
+  # pgrep categoryedit -af ${DIRECTORY}/etc/categoryedit
 
   # remove all output from the list if there is no second column (aka, there was not argument, meaning it is a GUI)
-  # pgrep categoryedit -a | sed -n "s:${DIRECTORY}/etc/categoryedit::p" | awk '{print $1, $3}' | awk '$2 != ""'
+  # pgrep categoryedit -af ${DIRECTORY}/etc/categoryedit | awk '{print $1, $3}' | awk '$2 != ""'
 
   # now only print the first column (the PIDs)
-  # pgrep categoryedit -a | sed -n "s:${DIRECTORY}/etc/categoryedit::p" | awk '{print $1, $3}' | awk '$2 != ""' | awk '{print $1}'
+  # pgrep categoryedit -af ${DIRECTORY}/etc/categoryedit | awk '{print $1, $3}' | awk '$2 != ""' | awk '{print $1}'
 
-  while [[ $(pgrep categoryedit -a | sed -n "s:${DIRECTORY}/etc/categoryedit::p" | awk '{print $1, $3}' | awk '$2 != ""' | awk '{print $1}' | sort | head -n 1) != $$ ]]; do
+  while [[ $(pgrep categoryedit -af ${DIRECTORY}/etc/categoryedit | awk '{print $1, $3}' | awk '$2 != ""' | awk '{print $1}' | sort | head -n 1) != $$ ]]; do
     # waiting for another instance of categoryedit to finish
     sleep 0.02
   done

--- a/etc/categoryedit
+++ b/etc/categoryedit
@@ -14,15 +14,15 @@ function error {
 if [ ! -z "$1" ];then
   # processes which are using categoryedit for scripting (not a GUI) will have additional column 3 and 4 output (the arguments)
   # output of below command is: PID /bin/bash ARG1 ARG2
-  # pgrep categoryedit -af ${DIRECTORY}/etc/categoryedit
+  # pgrep -af ${DIRECTORY}/etc/categoryedit
 
   # remove all output from the list if there is no second column (aka, there was not argument, meaning it is a GUI)
-  # pgrep categoryedit -af ${DIRECTORY}/etc/categoryedit | awk '{print $1, $3}' | awk '$2 != ""'
+  # pgrep -af ${DIRECTORY}/etc/categoryedit | awk '{print $1, $3}' | awk '$2 != ""'
 
   # now only print the first column (the PIDs)
-  # pgrep categoryedit -af ${DIRECTORY}/etc/categoryedit | awk '{print $1, $3}' | awk '$2 != ""' | awk '{print $1}'
+  # pgrep -af ${DIRECTORY}/etc/categoryedit | awk '{print $1, $3}' | awk '$2 != ""' | awk '{print $1}'
 
-  while [[ $(pgrep categoryedit -af ${DIRECTORY}/etc/categoryedit | awk '{print $1, $3}' | awk '$2 != ""' | awk '{print $1}' | sort | head -n 1) != $$ ]]; do
+  while [[ $(pgrep -af ${DIRECTORY}/etc/categoryedit | awk '{print $1, $3}' | awk '$2 != ""' | awk '{print $1}' | sort | head -n 1) != $$ ]]; do
     # waiting for another instance of categoryedit to finish
     sleep 0.02
   done

--- a/etc/categoryedit
+++ b/etc/categoryedit
@@ -9,6 +9,12 @@ function error {
   exit 1
 }
 
+#Only one instance of this script should run at a time. wait if another process other than this one is running
+while [[ $(pgrep categoryedit | sort |  head -n 1) != $$ ]]; do
+  # waiting for another instance of categoryedit to finish
+  sleep 0.02
+done
+
 #for read_category_files()
 if ! command -v read_category_files >/dev/null ;then
   source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"

--- a/etc/categoryedit
+++ b/etc/categoryedit
@@ -27,7 +27,7 @@ set_category() { #place the $1 app in the $2 category - don't write to files, on
   
   #store the contents of the global categories file and the local category-overrides file
   #these are purposely not local-variables.
-  [ -z "$local_categories" ] && local_categories="$(cat "${DIRECTORY}/data/category-overrides" 2>/dev/null)"
+  [ -z "$local_categories" ] && local_categories="$(cat "${DIRECTORY}/data/category-overrides")"
   [ -z "$global_categories" ] && global_categories="$(cat "${DIRECTORY}/etc/categories")"
   
   #the app may be: in both files, in global file, in overrides file, or in neither file
@@ -63,7 +63,7 @@ set_category() { #place the $1 app in the $2 category - don't write to files, on
 }
 
 save_changes() { #writes the $local_categories variable to the category-overrides file
-  if [ "$local_categories" == "$(cat "${DIRECTORY}/data/category-overrides" 2>/dev/null)" ];then
+  if [ "$local_categories" == "$(cat "${DIRECTORY}/data/category-overrides")" ];then
     #no changes would be made, so exit now
     return 0
   fi

--- a/etc/categoryedit
+++ b/etc/categoryedit
@@ -9,25 +9,6 @@ function error {
   exit 1
 }
 
-#Only one instance of this script should run at a time. wait if another process other than this one is running
-#skip this check if this instance does not have an ARG (running as a GUI)
-if [ ! -z "$1" ];then
-  # processes which are using categoryedit for scripting (not a GUI) will have additional column 4 and 5 output (the arguments)
-  # output of below command is: PID ARG1
-  # pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}'
-
-  # remove all output from the list if there is no second column (aka, there was not argument, meaning it is a GUI)
-  # pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}' | awk '$2 != ""'
-
-  # now only print the first column (the PIDs)
-  # pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}' | awk '$2 != ""' | awk '{print $1}'
-
-  while [[ $(pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}' | awk '$2 != ""' | awk '{print $1}' | sort | head -n 1) != $$ ]]; do
-    # waiting for another instance of categoryedit to finish
-    sleep 0.02
-  done
-fi
-
 #for read_category_files()
 if ! command -v read_category_files >/dev/null ;then
   source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"
@@ -82,9 +63,24 @@ set_category() { #place the $1 app in the $2 category - don't write to files, on
 }
 
 save_changes() { #writes the $local_categories variable to the category-overrides file
-  if [ "$local_categories" != "$(cat "${DIRECTORY}/data/category-overrides")" ];then
-    echo "$local_categories" > "${DIRECTORY}/data/category-overrides"
+  if [ "$local_categories" == "$(cat "${DIRECTORY}/data/category-overrides")" ];then
+    #no changes would be made, so exit now
+    return 0
   fi
+  
+  #Prevent category corruption with a lock file - if the file exists and contains a valid PID, wait.
+  if [ -f "${DIRECTORY}/data/category-overrides.lock" ];then
+    PID="$(cat "${DIRECTORY}/data/category-overrides.lock")"
+    echo -n "Waiting for categoryedit PID $PID to finish... "
+    while [ -d /proc/${PID} ];do
+      sleep 1
+    done
+    echo Done
+  fi
+  echo $$ > "${DIRECTORY}/data/category-overrides.lock"
+  sleep 1
+  echo "$local_categories" > "${DIRECTORY}/data/category-overrides"
+  rm -f "${DIRECTORY}/data/category-overrides.lock"
 }
 APPS="$(list_apps local)"
 

--- a/etc/categoryedit
+++ b/etc/categoryedit
@@ -27,7 +27,7 @@ set_category() { #place the $1 app in the $2 category - don't write to files, on
   
   #store the contents of the global categories file and the local category-overrides file
   #these are purposely not local-variables.
-  [ -z "$local_categories" ] && local_categories="$(cat "${DIRECTORY}/data/category-overrides")"
+  [ -z "$local_categories" ] && local_categories="$(cat "${DIRECTORY}/data/category-overrides" 2>/dev/null)"
   [ -z "$global_categories" ] && global_categories="$(cat "${DIRECTORY}/etc/categories")"
   
   #the app may be: in both files, in global file, in overrides file, or in neither file
@@ -63,7 +63,7 @@ set_category() { #place the $1 app in the $2 category - don't write to files, on
 }
 
 save_changes() { #writes the $local_categories variable to the category-overrides file
-  if [ "$local_categories" == "$(cat "${DIRECTORY}/data/category-overrides")" ];then
+  if [ "$local_categories" == "$(cat "${DIRECTORY}/data/category-overrides" 2>/dev/null)" ];then
     #no changes would be made, so exit now
     return 0
   fi

--- a/etc/categoryedit
+++ b/etc/categoryedit
@@ -10,10 +10,23 @@ function error {
 }
 
 #Only one instance of this script should run at a time. wait if another process other than this one is running
-while [[ $(pgrep categoryedit | sort |  head -n 1) != $$ ]]; do
-  # waiting for another instance of categoryedit to finish
-  sleep 0.02
-done
+#skip this check if this instance does not have an ARG (running as a GUI)
+if [ ! -z "$1" ];then
+  # processes which are using categoryedit for scripting (not a GUI) will have additional column 4 and 5 output (the arguments)
+  # output of below command is: PID ARG1
+  # pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}'
+
+  # remove all output from the list if there is no second column (aka, there was not argument, meaning it is a GUI)
+  # pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}' | awk '$2 != ""'
+
+  # now only print the first column (the PIDs)
+  # pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}' | awk '$2 != ""' | awk '{print $1}'
+
+  while [[ $(pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}' | awk '$2 != ""' | awk '{print $1}' | sort | head -n 1) != $$ ]]; do
+    # waiting for another instance of categoryedit to finish
+    sleep 0.02
+  done
+fi
 
 #for read_category_files()
 if ! command -v read_category_files >/dev/null ;then

--- a/etc/categoryedit
+++ b/etc/categoryedit
@@ -9,6 +9,25 @@ function error {
   exit 1
 }
 
+#Only one instance of this script should run at a time. wait if another process other than this one is running
+#skip this check if this instance does not have an ARG (running as a GUI)
+if [ ! -z "$1" ];then
+  # processes which are using categoryedit for scripting (not a GUI) will have additional column 4 and 5 output (the arguments)
+  # output of below command is: PID ARG1
+  # pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}'
+
+  # remove all output from the list if there is no second column (aka, there was not argument, meaning it is a GUI)
+  # pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}' | awk '$2 != ""'
+
+  # now only print the first column (the PIDs)
+  # pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}' | awk '$2 != ""' | awk '{print $1}'
+
+  while [[ $(pgrep categoryedit | xargs ps -o pid,cmd h | awk '{print $1, $4}' | awk '$2 != ""' | awk '{print $1}' | sort | head -n 1) != $$ ]]; do
+    # waiting for another instance of categoryedit to finish
+    sleep 0.02
+  done
+fi
+
 #for read_category_files()
 if ! command -v read_category_files >/dev/null ;then
   source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"
@@ -63,24 +82,9 @@ set_category() { #place the $1 app in the $2 category - don't write to files, on
 }
 
 save_changes() { #writes the $local_categories variable to the category-overrides file
-  if [ "$local_categories" == "$(cat "${DIRECTORY}/data/category-overrides")" ];then
-    #no changes would be made, so exit now
-    return 0
+  if [ "$local_categories" != "$(cat "${DIRECTORY}/data/category-overrides")" ];then
+    echo "$local_categories" > "${DIRECTORY}/data/category-overrides"
   fi
-  
-  #Prevent category corruption with a lock file - if the file exists and contains a valid PID, wait.
-  if [ -f "${DIRECTORY}/data/category-overrides.lock" ];then
-    PID="$(cat "${DIRECTORY}/data/category-overrides.lock")"
-    echo -n "Waiting for categoryedit PID $PID to finish... "
-    while [ -d /proc/${PID} ];do
-      sleep 1
-    done
-    echo Done
-  fi
-  echo $$ > "${DIRECTORY}/data/category-overrides.lock"
-  sleep 1
-  echo "$local_categories" > "${DIRECTORY}/data/category-overrides"
-  rm -f "${DIRECTORY}/data/category-overrides.lock"
 }
 APPS="$(list_apps local)"
 

--- a/etc/categoryedit
+++ b/etc/categoryedit
@@ -57,7 +57,9 @@ set_category() { #place the $1 app in the $2 category - don't write to files, on
 }
 
 save_changes() { #writes the $local_categories variable to the category-overrides file
-  echo "$local_categories" > "${DIRECTORY}/data/category-overrides"
+  if [ "$local_categories" != "$(cat "${DIRECTORY}/data/category-overrides")" ];then
+    echo "$local_categories" > "${DIRECTORY}/data/category-overrides"
+  fi
 }
 APPS="$(list_apps local)"
 

--- a/etc/preload-daemon
+++ b/etc/preload-daemon
@@ -42,7 +42,7 @@ if [ -z "${text_color+x}" ];then
   #0400 is the latest version
   yad_version="$(zcat /usr/share/doc/yad/NEWS.gz | head -n 1 | tr -cd '0123456789\n')"
   if [ $yad_version -lt 0400 ]; then
-    text_color=$(echo "import gi
+    export text_color=$(echo "import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -56,10 +56,9 @@ textcolor = style.get_color(Gtk.StateType.NORMAL)
 print(Gdk.RGBA.to_string(textcolor))
 " | python -)
   else
-    text_color=""
+    export text_color=""
   fi
 fi
-export text_color
 
 #runs every 30 secs for 10 mins
 for i in {1..20};do

--- a/etc/preload-daemon
+++ b/etc/preload-daemon
@@ -29,10 +29,10 @@ source "${DIRECTORY}/preload" "source"
 #variable 2 is 'once', if you only want this to run once and exit.
 
 #generate list of folders to preload, including special folders
-folders="$(read_category_files | awk -F '|' '{print $2}' | sort | uniq | grep .)
+folders="All Apps
+$(read_category_files | awk -F '|' '{print $2}' | sort | uniq | grep .)
 Installed
-Packages
-All Apps"
+Packages"
 #echo "$folders"
 
 IFS=$'\n'

--- a/etc/preload-daemon
+++ b/etc/preload-daemon
@@ -81,10 +81,14 @@ for i in {1..20};do
   if [ "$timestamps" != "$pretimestamps" ];then
     
     "${DIRECTORY}/preload" "$guimode" &>/dev/null
+    local IFS=$'\n'
+    local PIDS=()
     for folder in $folders ; do
       echo "Preloading $folder..." 1>&2
-      "${DIRECTORY}/preload" "$guimode" "$folder" &>/dev/null
+      "${DIRECTORY}/preload" "$guimode" "$folder" &>/dev/null &
+      PIDS+=("$!")
     done
+    wait "${PIDS[@]}" #wait for all subprocesses to complete
     echo done 1>&2
   else
     echo "Preloading skipped; nothing was changed" 1>&2

--- a/etc/preload-daemon
+++ b/etc/preload-daemon
@@ -2,6 +2,11 @@
 
 #runs in the background and refreshes all the list files
 
+#Only one instance of this script should run at a time. If this is removed, preload will form a fairly good fork bomb.
+if [ "$(pgrep preload-daemon | wc -l)" -gt 2 ];then
+  exit 0
+fi
+
 DIRECTORY="$(dirname "$(readlink -f "$(dirname "$0")")")"
 
 function error {
@@ -9,33 +14,20 @@ function error {
   exit 1
 }
 
-#Only one instance of this script should run at a time. Exit now if another process other than this one is running
-proc="$(pgrep preload-daemon)"
-num_proc="$(echo "$proc" | wc -l)"
-if [ "$2" != 'once' ] && [ "$num_proc" -gt 1 ];then
-  echo "Preload-daemon is already running." 1>&2
-  exit 0
-else
-  echo "Running preload-daemon..." 1>&2
-fi
-
 #for refresh_all_pkgapp_status function, and to prevent preload script from sourcing api
-source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"
+if ! command -v read_category_files >/dev/null ;then
+  source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"
+fi
 
 #for mktimestamps function
 source "${DIRECTORY}/preload" "source"
 
-#variable 1 is yad or xlunch
-#variable 2 is 'once', if you only want this to run once and exit.
-
-#generate list of folders to preload, including special folders
+#list of folders to preload, including special folders
 folders="All Apps
 $(read_category_files | awk -F '|' '{print $2}' | sort | uniq | grep .)
 Installed
 Packages"
 #echo "$folders"
-
-IFS=$'\n'
 
 #For systems with older versions of yad, the text color column cannot be left blank. This python script determines the default text color from GTK bindings.
 if [ -z "${text_color+x}" ];then
@@ -60,41 +52,34 @@ print(Gdk.RGBA.to_string(textcolor))
   fi
 fi
 
-#runs every 30 secs for 10 mins
-for i in {1..20};do
+#hide package-apps that are unavailable in the repositories, and change their status accordingly
+#only run this if the /var/lib/dpkg/status has been changed since last time
+if [ "$(stat -c %Y /var/lib/dpkg/status 2>/dev/null)" != "$(cat "${DIRECTORY}/data/preload/timestamps-dpkg-status" 2>/dev/null)" ];then
+  echo "Refreshing pkgapp_status..." 1>&2
+  stat -c %Y /var/lib/dpkg/status 2>/dev/null > "${DIRECTORY}/data/preload/timestamps-dpkg-status"
+  refresh_all_pkgapp_status &
+fi
+
+#get modified timestamps for files/directories in the pi-apps folder
+timestamps="$(mktimestamps)"
+
+#determine the app list style (it may change)
+guimode="$(cat "${DIRECTORY}/data/settings/App List Style" 2>/dev/null)"
+
+#only re-preload everything if something in the pi-apps folder was changed
+if [ "$timestamps" != "$(cat "${DIRECTORY}/data/preload/timestamps-preload-daemon" 2>/dev/null)" ];then
   
-  #hide package-apps that are unavailable in the repositories, and change their status accordingly
-  #only run this if the /var/lib/dpkg/status has been changed since last time
-  if [ "$(stat -c %Y /var/lib/dpkg/status 2>/dev/null)" != "$(cat "${DIRECTORY}/data/preload/timestamps-dpkg-status" 2>/dev/null)" ];then
-    echo "Refreshing pkgapp_status..." 1>&2
-    stat -c %Y /var/lib/dpkg/status 2>/dev/null > "${DIRECTORY}/data/preload/timestamps-dpkg-status"
-    refresh_all_pkgapp_status &
-  fi
+  echo "Preload-daemon running..." 1>&2
+  IFS=$'\n'
+  PIDS=()
+  for folder in $folders ; do
+    "${DIRECTORY}/preload" "$guimode" "$folder" &>/dev/null &
+    PIDS+=("$!")
+  done
+  wait "${PIDS[@]}" #wait for all subprocesses to complete
+  echo done 1>&2
   
-  #get modified timestamps for files/directories in the pi-apps folder
-  timestamps="$(mktimestamps)"
-  
-  #determine the app list style (it may change)
-  guimode="$(cat "${DIRECTORY}/data/settings/App List Style")"
-  
-  #only re-preload everything if something in the pi-apps folder was changed
-  if [ "$timestamps" != "$pretimestamps" ];then
-    
-    "${DIRECTORY}/preload" "$guimode" &>/dev/null
-    local IFS=$'\n'
-    local PIDS=()
-    for folder in $folders ; do
-      echo "Preloading $folder..." 1>&2
-      "${DIRECTORY}/preload" "$guimode" "$folder" &>/dev/null &
-      PIDS+=("$!")
-    done
-    wait "${PIDS[@]}" #wait for all subprocesses to complete
-    echo done 1>&2
-  else
-    echo "Preloading skipped; nothing was changed" 1>&2
-  fi
-  
-  [ "$2" == 'once' ] && exit 0 #if the $2 flag to this script is 'once', then it will only preload everything once.
-  sleep 30
-  pretimestamps="$timestamps"
-done
+  echo "$timestamps" > "${DIRECTORY}/data/preload/timestamps-preload-daemon"
+else
+  echo "Preload-daemon skipped; nothing was changed" 1>&2
+fi

--- a/etc/preload-daemon
+++ b/etc/preload-daemon
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+#Only one instance of this script should run at a time. Exit now if another process other than this one is running
+if [ "$2" != 'once' ] && [ "$(pgrep preload-daemon | wc -l)" -gt 1 ];then
+  echo "Preload-daemon is already running." 1>&2
+  exit 0
+else
+  echo "Running preload-daemon..." 1>&2
+fi
+
 #runs in the background and refreshes all the list files
 
 DIRECTORY="$(dirname "$(readlink -f "$(dirname "$0")")")"
@@ -8,16 +16,6 @@ function error {
   echo -e "\e[91m$1\e[39m"
   exit 1
 }
-
-#Only one instance of this script should run at a time. Exit now if another process other than this one is running
-proc="$(pgrep preload-daemon)"
-num_proc="$(echo "$proc" | wc -l)"
-if [ "$2" != 'once' ] && [ "$num_proc" -gt 1 ];then
-  echo "Preload-daemon is already running." 1>&2
-  exit 0
-else
-  echo "Running preload-daemon..." 1>&2
-fi
 
 #for refresh_all_pkgapp_status function, and to prevent preload script from sourcing api
 source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"

--- a/etc/preload-daemon
+++ b/etc/preload-daemon
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-#Only one instance of this script should run at a time. Exit now if another process other than this one is running
-if [ "$2" != 'once' ] && [ "$(pgrep preload-daemon | wc -l)" -gt 1 ];then
-  echo "Preload-daemon is already running." 1>&2
-  exit 0
-else
-  echo "Running preload-daemon..." 1>&2
-fi
-
 #runs in the background and refreshes all the list files
 
 DIRECTORY="$(dirname "$(readlink -f "$(dirname "$0")")")"
@@ -16,6 +8,16 @@ function error {
   echo -e "\e[91m$1\e[39m"
   exit 1
 }
+
+#Only one instance of this script should run at a time. Exit now if another process other than this one is running
+proc="$(pgrep preload-daemon)"
+num_proc="$(echo "$proc" | wc -l)"
+if [ "$2" != 'once' ] && [ "$num_proc" -gt 1 ];then
+  echo "Preload-daemon is already running." 1>&2
+  exit 0
+else
+  echo "Running preload-daemon..." 1>&2
+fi
 
 #for refresh_all_pkgapp_status function, and to prevent preload script from sourcing api
 source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"

--- a/etc/preload-daemon
+++ b/etc/preload-daemon
@@ -70,13 +70,9 @@ guimode="$(cat "${DIRECTORY}/data/settings/App List Style" 2>/dev/null)"
 if [ "$timestamps" != "$(cat "${DIRECTORY}/data/preload/timestamps-preload-daemon" 2>/dev/null)" ];then
   
   echo "Preload-daemon running..." 1>&2
-  IFS=$'\n'
-  PIDS=()
   for folder in $folders ; do
-    "${DIRECTORY}/preload" "$guimode" "$folder" &>/dev/null &
-    PIDS+=("$!")
+    "${DIRECTORY}/preload" "$guimode" "$folder" &>/dev/null
   done
-  wait "${PIDS[@]}" #wait for all subprocesses to complete
   echo done 1>&2
   
   echo "$timestamps" > "${DIRECTORY}/data/preload/timestamps-preload-daemon"

--- a/gui
+++ b/gui
@@ -17,7 +17,7 @@ if [ -z "${text_color+x}" ];then
   #0400 is the latest version
   yad_version="$(zcat /usr/share/doc/yad/NEWS.gz | head -n 1 | tr -cd '0123456789\n')"
   if [ $yad_version -lt 0400 ]; then
-    text_color=$(echo "import gi
+    export text_color=$(echo "import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -31,10 +31,9 @@ textcolor = style.get_color(Gtk.StateType.NORMAL)
 print(Gdk.RGBA.to_string(textcolor))
 " | python -)
   else
-    text_color=""
+    export text_color=""
   fi
 fi
-export text_color
 
 terminal_manage() { #function to install/uninstall one app - uses a terminal and refreshes the app list
   if [ "$1" == 'uninstall' ];then

--- a/gui
+++ b/gui
@@ -303,6 +303,15 @@ source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"
 #display the pi-apps logo in the terminal
 generate_logo &
 
+#install dependencies
+runonce <<"EOF"
+  dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils'
+  # Install dependencies if necessary
+  if ! dpkg -s $dependencies >/dev/null 2>&1; then
+    sudo_popup apt install $dependencies -y -f --no-install-recommends
+  fi
+EOF
+
 #Various stuff to run in background (enclosed in brackets so Geany IDE can collapse the code)
 {
 
@@ -332,15 +341,6 @@ trap "kill $! &>/dev/null" EXIT #kill the above subprocess on exit
 #remove contents of ${DIRECTORY}/data/preload
 runonce <<"EOF"
   rm -rf  "${DIRECTORY}/data/preload"
-EOF
-
-#install dependencies
-runonce <<"EOF"
-  dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils'
-  # Install dependencies if necessary
-  if ! dpkg -s $dependencies >/dev/null 2>&1; then
-    sudo_popup apt install $dependencies -y -f --no-install-recommends
-  fi
 EOF
 
 #regenerate package-app status for one-time migration

--- a/gui
+++ b/gui
@@ -315,8 +315,12 @@ EOF
 #Various stuff to run in background (enclosed in brackets so Geany IDE can collapse the code)
 {
 
+mkdir -p "${DIRECTORY}/data/status" "${DIRECTORY}/data/update-status" \
+  "${DIRECTORY}/data/preload" "${DIRECTORY}/data/settings" \
+  "${DIRECTORY}/data/status" "${DIRECTORY}/data/update-status" \
+  "${DIRECTORY}/data/categories"
+
 #check for updates
-mkdir -p "${DIRECTORY}/data/status" "${DIRECTORY}/data/update-status"
 "${DIRECTORY}/updater" set-status &>/dev/null &
 trap "kill $! &>/dev/null" EXIT #kill the above subprocess on exit
 
@@ -338,9 +342,11 @@ trap "kill $! &>/dev/null" EXIT #kill the above subprocess on exit
 
 #runonce entries
 (
-#remove contents of ${DIRECTORY}/data/preload
+#generate settings
 runonce <<"EOF"
-  rm -rf  "${DIRECTORY}/data/preload"
+  if [ "$(ls "$DIRECTORY/data/settings" 2>/dev/null | wc -l)" -le 2 ];then
+    "${DIRECTORY}/settings" refresh
+  fi
 EOF
 
 #regenerate package-app status for one-time migration

--- a/gui
+++ b/gui
@@ -334,6 +334,25 @@ runonce <<"EOF"
   rm -rf  "${DIRECTORY}/data/preload"
 EOF
 
+#install dependencies
+runonce <<"EOF"
+  dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils'
+  # Install dependencies if necessary
+  if ! dpkg -s $dependencies >/dev/null 2>&1; then
+    sudo_popup apt install $dependencies -y -f --no-install-recommends
+  fi
+EOF
+
+#regenerate package-app status for one-time migration
+runonce <<"EOF"
+  IFS=$'\n'
+  for app in $(list_apps package) ;do
+    rm -f "${DIRECTORY}/data/status/${app}" || exit 1
+  done
+  
+  refresh_all_pkgapp_status
+EOF
+
 #mark wine and box86 as disabled, if twisteros
 runonce <<"EOF"
   if [ -f /usr/local/bin/twistver ] && command -v wine >/dev/null ;then
@@ -426,15 +445,6 @@ runonce <<"EOF"
   fi
 EOF
 
-#install dependencies
-runonce <<"EOF"
-  dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils'
-  # Install dependencies if necessary
-  if ! dpkg -s $dependencies >/dev/null 2>&1; then
-    sudo_popup apt install $dependencies -y -f --no-install-recommends
-  fi
-EOF
-
 #transition from box86-no-binfmt-restart package to box86
 runonce <<"EOF"
   if dpkg -l box86-no-binfmt-restart &>/dev/null ;then
@@ -454,16 +464,6 @@ EOF
 runonce <<"EOF"
   rm -f "${DIRECTORY}/etc/bitlylink"
   rm -rf "${DIRECTORY}/data/categories"
-EOF
-
-#regenerate package-app status for one-time migration
-runonce <<"EOF"
-  IFS=$'\n'
-  for app in $(list_apps package) ;do
-    rm -f "${DIRECTORY}/data/status/${app}" || exit 1
-  done
-  
-  refresh_all_pkgapp_status
 EOF
 
 #change settings icon

--- a/gui
+++ b/gui
@@ -359,23 +359,6 @@ runonce <<"EOF"
   refresh_all_pkgapp_status
 EOF
 
-#mark wine and box86 as disabled, if twisteros
-runonce <<"EOF"
-  if [ -f /usr/local/bin/twistver ] && command -v wine >/dev/null ;then
-    echo 'disabled' > "${DIRECTORY}/data/status/Wine (x86)"
-  fi
-  if [ -f /usr/local/bin/twistver ] && command -v box86 >/dev/null ;then
-    echo 'disabled' > "${DIRECTORY}/data/status/Box86"
-  fi
-EOF
-
-#re-run install script on twistos lite to re-show some previously hidden apps
-runonce <<"EOF"
-if [ -f /usr/local/bin/twistver ] && [[ "$(twistver)" != 'Twister OS version'* ]];then
-  "${DIRECTORY}/install"
-fi
-EOF
-
 #remove old apps and migrate chromium downgrading apps to the new "Downgrade Chromium" app
 runonce <<"EOF"
   #rework chromium downgrading apps to one single new app: 'Downgrade Chromium'

--- a/install
+++ b/install
@@ -101,61 +101,10 @@ X-GNOME-Autostart-enabled=true
 Hidden=false
 NoDisplay=false" > ~/.config/autostart/pi-apps-updater.desktop
 
-mkdir -p "${DIRECTORY}/data" && cd "${DIRECTORY}/data" || error "Failed to make and enter ${DIRECTORY}/data directory!"
-mkdir -p installed-packages preload settings status update-status categories
-cd $HOME
-
-#hide template app by default
-"${DIRECTORY}/etc/categoryedit" "template" 'hidden' &>/dev/null
-
-#hide duplicates if running in twisteros
-if [ -f /usr/local/bin/twistver ] && [[ $(twistver) == "Twister OS version"* ]]; then
-  #twisteros full
-  apps="CommanderPi
-Box86
-Discord
-piKiss
-Retropie
-Scrcpy
-Steam
-Windows 10 Theme
-Chromium Widevine
-Lightpad
-Wine (x86)
-Mac OS Theme"
-  PREIFS="$IFS"
-  IFS=$'\n'
-  for app in $apps ;do
-    "${DIRECTORY}/etc/categoryedit" "$app" 'hidden' >/dev/null
-  done
-  IFS="$PREIFS"
-  
-elif [ -f /usr/local/bin/twistver ] && [[ $(twistver) != "Twister OS version"* ]]; then
-  #twisteros lite
-  PREIFS="$IFS"
-  IFS=$'\n'
-  apps="Chromium Widevine
-Box86
-Windows 10 Theme
-Lightpad
-Wine (x86)
-Mac OS Theme"
-  for app in $apps ;do
-    "${DIRECTORY}/etc/categoryedit" "$app" 'hidden' >/dev/null
-  done
-  IFS="$PREIFS"
-  
-  #unhide some apps on twisteros lite that were hidden.
-  #This removes certain apps completely from the category file. Effectively resets them to online default.
-  "${DIRECTORY}/etc/categoryedit" CommanderPi --delete >/dev/null
-  "${DIRECTORY}/etc/categoryedit" Discord --delete >/dev/null
-  "${DIRECTORY}/etc/categoryedit" piKiss --delete >/dev/null
-  "${DIRECTORY}/etc/categoryedit" Scrcpy --delete >/dev/null
-  "${DIRECTORY}/etc/categoryedit" Steam --delete >/dev/null
-  "${DIRECTORY}/etc/categoryedit" 'Chromium Widevine' --delete >/dev/null
-  
-  echo "Finished hiding apps on TwisterOS."
-fi
+mkdir -p "${DIRECTORY}/data/status" "${DIRECTORY}/data/update-status" \
+  "${DIRECTORY}/data/preload" "${DIRECTORY}/data/settings" \
+  "${DIRECTORY}/data/status" "${DIRECTORY}/data/update-status" \
+  "${DIRECTORY}/data/categories"
 
 #pi-apps terminal command
 if [ ! -f /usr/local/bin/pi-apps ] || ! cat /usr/local/bin/pi-apps | grep -q "${DIRECTORY}/gui" ;then

--- a/preload
+++ b/preload
@@ -156,7 +156,7 @@ if [ $reloadlist == 1 ];then
   DIRS="$(grep '/' <<<"$vfiles" | tr -d '/')"
   
   #shuffle the list if enabled
-  if [ "$(while read line; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/settings/Shuffle App list")" == 'Yes' ];then
+  if [ "$(< "${DIRECTORY}/data/settings/Shuffle App list")" == 'Yes' ];then
     APPS="$(echo "$APPS" | shuf)"
     DIRS="$(echo "$DIRS" | shuf)"
   fi
@@ -285,7 +285,7 @@ $prefix/$app
     for app in $APPS
     do
       if [ -f "${DIRECTORY}/data/status/${app}" ];then
-        echo "${app} ($(while read line; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/status/${app}" 2>/dev/null));${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
+        echo "${app} ($(< "${DIRECTORY}/data/status/${app}" 2>/dev/null));${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
       else
         #status file missing - app has never been installed
         echo "${app};${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""

--- a/preload
+++ b/preload
@@ -255,7 +255,7 @@ $prefix/$app
     mv "$listfile_tmp" "$listfile"
     # specifically use cat here so that all data enters the pipe at once
     cat "$listfile"
-    echo "Finished preload for $prefix" 1>&2
+    echo "Finished preload for '$prefix'" 1>&2
     #finished preloading apps
     
   elif [ "$format" == xlunch ];then

--- a/preload
+++ b/preload
@@ -156,7 +156,7 @@ if [ $reloadlist == 1 ];then
   DIRS="$(grep '/' <<<"$vfiles" | tr -d '/')"
   
   #shuffle the list if enabled
-  if [ "$(while read line; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/settings/Shuffle App list")" == 'Yes' ];then
+  if [ "$(< "${DIRECTORY}/data/settings/Shuffle App list")" == 'Yes' ];then
     APPS="$(echo "$APPS" | shuf)"
     DIRS="$(echo "$DIRS" | shuf)"
   fi
@@ -209,7 +209,7 @@ $text_color"
     for app in $APPS
     do
       #get installation status of app
-      status="$(while read line ; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/status/${app}")"
+      status="$(< "${DIRECTORY}/data/status/${app}")"
       
       #determine app icon
       if [ -f "${DIRECTORY}/apps/${app}/icon-24.png" ];then
@@ -285,7 +285,7 @@ $prefix/$app
     for app in $APPS
     do
       if [ -f "${DIRECTORY}/data/status/${app}" ];then
-        echo "${app} ($(while read line; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/status/${app}" 2>/dev/null));${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
+        echo "${app} ($(< "${DIRECTORY}/data/status/${app}" 2>/dev/null));${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
       else
         #status file missing - app has never been installed
         echo "${app};${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""

--- a/preload
+++ b/preload
@@ -62,7 +62,7 @@ if [ -z "${text_color+x}" ] && [ "$format" == yad ];then
   #0400 is the latest version
   yad_version="$(zcat /usr/share/doc/yad/NEWS.gz | head -n 1 | tr -cd '0123456789\n')"
   if [ $yad_version -lt 0400 ]; then
-    text_color=$(echo "import gi
+    export text_color=$(echo "import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -76,10 +76,9 @@ textcolor = style.get_color(Gtk.StateType.NORMAL)
 print(Gdk.RGBA.to_string(textcolor))
 " | python -)
   else
-    text_color=""
+    export text_color=""
   fi
 fi
-export text_color
 
 timestampfile="${DIRECTORY}/data/preload/timestamps-$(echo "$prefix" | tr -d '/')"
 listfile="${DIRECTORY}/data/preload/LIST-$(echo "$prefix" | tr -d '/')"

--- a/preload
+++ b/preload
@@ -209,7 +209,7 @@ $text_color"
     for app in $APPS
     do
       #get installation status of app
-      status="$(while read line ; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/status/${app}")"
+      read -r 2>/dev/null status <"${DIRECTORY}/data/status/${app}"
       
       #determine app icon
       if [ -f "${DIRECTORY}/apps/${app}/icon-24.png" ];then

--- a/preload
+++ b/preload
@@ -219,12 +219,12 @@ $text_color"
       
       #rest of list attributes
       if [ -z "$status" ];then
-        read -r 2>/dev/null line <"${DIRECTORY}/apps/Discord/description" || line="Description unavailable"
+        read -r 2>/dev/null line <"${DIRECTORY}/apps/${app}/description" || line="Description unavailable"
         add+="$app
 $prefix/$app
 $line"$'\n'
       else
-        read -r 2>/dev/null line <"${DIRECTORY}/apps/Discord/description" || line="Description unavailable"
+        read -r 2>/dev/null line <"${DIRECTORY}/apps/${app}/description" || line="Description unavailable"
         add+="$app
 $prefix/$app
 "\("$status"\)" $line"$'\n'

--- a/preload
+++ b/preload
@@ -251,6 +251,7 @@ $prefix/$app
 
     # write to the pipe all at once instead of in breaking chunks. this prevents errors when user clicks the back button too quickly when the list file is still generating
     mv "$listfile_tmp" "$listfile"
+    # specifically use cat here so that all data enters the pipe at once
     cat "$listfile"
     echo "Finished preload for $prefix" 1>&2
     #finished preloading apps
@@ -290,7 +291,8 @@ $prefix/$app
     done | tee -a "$listfile_tmp" 2&>/dev/null
 
     # write to the pipe all at once instead of in breaking chunks. this prevents errors when user clicks the back button too quickly when the list file is still generating
-    mv "$listfile_tmp" "$listfile"    
+    mv "$listfile_tmp" "$listfile"
+    # specifically use cat here so that all data enters the pipe at once
     cat "$listfile"
     echo "Finished preload for $prefix" 1>&2
     
@@ -303,6 +305,7 @@ $prefix/$app
   echo "$timestamps" > "$timestampfile"
 else
   echo "Reading list file for '$prefix'..." 1>&2
+  # specifically use cat here so that all data enters the pipe at once
   cat "$listfile"
 fi
 

--- a/preload
+++ b/preload
@@ -285,7 +285,7 @@ $prefix/$app
     for app in $APPS
     do
       if [ -f "${DIRECTORY}/data/status/${app}" ];then
-        echo "${app} ($(< "${DIRECTORY}/data/status/${app}" 2>/dev/null));${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
+        echo "${app} ($(while read line; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/status/${app}" 2>/dev/null));${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
       else
         #status file missing - app has never been installed
         echo "${app};${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""

--- a/preload
+++ b/preload
@@ -143,17 +143,17 @@ if [ $reloadlist == 1 ];then
     echo "Showing apps within $prefix/" 1>&2
     vfiles="$(app_prefix_category "$prefix" | grep . | sort -f | uniq | sed "s+$prefix/++g")" #generate a virtual file system with apps in folders represented as subdirectories
   else
-    vfiles="$(app_categories | grep . | sort -f | uniq)"
+    vfiles="$(app_categories | grep . | sort -f | uniq | grep -v '^hidden/')"
   fi
   
   #remove apps within categories - show this layer of stuff only.
-  vfiles="$(sed 's+/.*+/+g' <<<"$vfiles" | sort -f | uniq)"
+  vfiles="$(sed 's+/.*+/+g' <<<"$vfiles" | uniq)"
   
   #get list of apps - excluding folders and apps that are incompatible with CPU architecture
   APPS="$(grep -v '/' <<<"$vfiles" | list_intersect "$(list_apps cpu_installable)")"
   
-  #get list of folders - excluding apps - and hide the hidden folder.
-  DIRS="$(grep '/' <<<"$vfiles" | tr -d '/' | grep -vFx "hidden")"
+  #get list of folders - excluding apps.
+  DIRS="$(grep '/' <<<"$vfiles" | tr -d '/')"
   
   #shuffle the list if enabled
   if [ "$(while read line; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/settings/Shuffle App list")" == 'Yes' ];then

--- a/preload
+++ b/preload
@@ -156,7 +156,7 @@ if [ $reloadlist == 1 ];then
   DIRS="$(grep '/' <<<"$vfiles" | tr -d '/')"
   
   #shuffle the list if enabled
-  if [ "$(< "${DIRECTORY}/data/settings/Shuffle App list")" == 'Yes' ];then
+  if [ "$(while read line; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/settings/Shuffle App list")" == 'Yes' ];then
     APPS="$(echo "$APPS" | shuf)"
     DIRS="$(echo "$DIRS" | shuf)"
   fi
@@ -209,7 +209,7 @@ $text_color"
     for app in $APPS
     do
       #get installation status of app
-      status="$(< "${DIRECTORY}/data/status/${app}")"
+      status="$(while read line ; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/status/${app}")"
       
       #determine app icon
       if [ -f "${DIRECTORY}/apps/${app}/icon-24.png" ];then
@@ -285,7 +285,7 @@ $prefix/$app
     for app in $APPS
     do
       if [ -f "${DIRECTORY}/data/status/${app}" ];then
-        echo "${app} ($(< "${DIRECTORY}/data/status/${app}" 2>/dev/null));${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
+        echo "${app} ($(while read line; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/status/${app}" 2>/dev/null));${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
       else
         #status file missing - app has never been installed
         echo "${app};${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""

--- a/preload
+++ b/preload
@@ -176,7 +176,9 @@ $text_color" | tee "$listfile_tmp" 2&>/dev/null
     else
       echo -n '' > "$listfile_tmp"
     fi
-    
+
+    declare -A dir_lookup
+    dir_lookup=( ["Browsers"]="Internet browsers." ["All Apps"]="All Pi-Apps Applications in one long list." ["Appearance"]="Applications and Themes which modify the look and feel of your OS." ["System Management"]="Apps that help you keep track of system resources and general system management." ["Games"]="Games and Emulators" ["Installed"]="All Pi-Apps Apps that you have installed." ["Internet"]="Browsers, Chat Clients, Email Clients, and so much more." ["Multimedia"]="Video playback and creation, audio playback and creation, and streaming alternatives." ["Packages"]="Simple Apps that install directly from APT repos." ["Tools"]="An assortment of helpful programs that don't already fit into another category." ["Terminals"]="Alternative terminal programs built for the modern age as well as to replicate your old vintage computer." ["Programming"]="Code editors, IDEs, and other applications to help you write and make other programs." ["Creative Arts"]="Drawing, Painting, and Photo and Movie Editors" ["Engineering"]="3D Printing slicers, CAD/modeling, and general design software" ["Office"]="Office suites (document and slideshow editors), and other office tools." ["Emulation"]="Applications that help you run non-ARM or non-Linux software." ["Communication"]="Internet messaging, calling, video chatting, and email clients.")
     for dir in $DIRS
     do
       if [ -f "${DIRECTORY}/icons/categories/${dir}.png" ];then
@@ -184,8 +186,6 @@ $text_color" | tee "$listfile_tmp" 2&>/dev/null
       else
         diricon="${DIRECTORY}/icons/categories/default.png"
       fi
-      declare -A dir_lookup
-      dir_lookup=( ["Browsers"]="Internet browsers." ["All Apps"]="All Pi-Apps Applications in one long list." ["Appearance"]="Applications and Themes which modify the look and feel of your OS." ["System Management"]="Apps that help you keep track of system resources and general system management." ["Games"]="Games and Emulators" ["Installed"]="All Pi-Apps Apps that you have installed." ["Internet"]="Browsers, Chat Clients, Email Clients, and so much more." ["Multimedia"]="Video playback and creation, audio playback and creation, and streaming alternatives." ["Packages"]="Simple Apps that install directly from APT repos." ["Tools"]="An assortment of helpful programs that don't already fit into another category." ["Terminals"]="Alternative terminal programs built for the modern age as well as to replicate your old vintage computer." ["Programming"]="Code editors, IDEs, and other applications to help you write and make other programs." ["Creative Arts"]="Drawing, Painting, and Photo and Movie Editors" ["Engineering"]="3D Printing slicers, CAD/modeling, and general design software" ["Office"]="Office suites (document and slideshow editors), and other office tools." ["Emulation"]="Applications that help you run non-ARM or non-Linux software." ["Communication"]="Internet messaging, calling, video chatting, and email clients.")
 
       if [ ! -z "$prefix" ];then
         add="$diricon

--- a/preload
+++ b/preload
@@ -200,8 +200,9 @@ $dir/
 "${dir_lookup["$dir"]}"
 $text_color"
       fi
+      add="${add//[&]/&amp;}"
       echo "$add"
-    done | sed 's/&/&amp;/g' >> "$listfile_tmp"
+    done >> "$listfile_tmp"
     #finished preloading categories
     
     #preload apps
@@ -246,8 +247,9 @@ $prefix/$app
         add+="$text_color"
       fi
       #output finished app lines
+      add="${add//[&]/&amp;}"
       echo "$add"
-    done | sed 's/&/&amp;/g' >> "$listfile_tmp"
+    done >> "$listfile_tmp"
 
     # write to the pipe all at once instead of in breaking chunks. this prevents errors when user clicks the back button too quickly when the list file is still generating
     mv "$listfile_tmp" "$listfile"

--- a/preload
+++ b/preload
@@ -14,7 +14,6 @@ ${DIRECTORY}/data/settings
 ${DIRECTORY}/data/status
 ${DIRECTORY}/etc
 ${DIRECTORY}/icons/categories
-${DIRECTORY}/apps
 ${DIRECTORY}/preload
 ${DIRECTORY}/api
 ${DIRECTORY}/data/category-overrides"

--- a/preload
+++ b/preload
@@ -172,7 +172,7 @@ if [ $reloadlist == 1 ];then
 Back
 $(dirname "$prefix" | sed 's+^\.$++g')/
 Return to the previous location
-$text_color" | tee "$listfile"
+$text_color" | tee "$listfile" 2&>/dev/null
     else
       echo -n '' > "$listfile"
     fi
@@ -201,7 +201,7 @@ $dir/
 $text_color"
       fi
       echo "$add"
-    done | sed 's/&/&amp;/g' | tee -a "$listfile"
+    done | sed 's/&/&amp;/g' | tee -a "$listfile" 2&>/dev/null
     #finished preloading categories
     
     #preload apps
@@ -245,7 +245,11 @@ $prefix/$app
       fi
       #output finished app lines
       echo "$add"
-    done | sed 's/&/&amp;/g' | tee -a "$listfile"
+    done | sed 's/&/&amp;/g' | tee -a "$listfile" 2&>/dev/null
+
+    # write to the pipe all at once instead of in breaking chunks. this prevents errors when user clicks the back button too quickly when the list file is still generating
+    cat "$listfile"
+    echo "Finished preload for $prefix" 1>&2
     #finished preloading apps
     
   elif [ "$format" == xlunch ];then
@@ -253,7 +257,7 @@ $prefix/$app
     
     #initial value of listfile: if within a prefix, start with a Back button, or if on main page start with Updates
     if [ ! -z "$prefix" ];then
-      echo "Back;${DIRECTORY}/icons/back-64.png;:exec "\""echo /"\""" | tee "$listfile"
+      echo "Back;${DIRECTORY}/icons/back-64.png;:exec "\""echo /"\""" | tee "$listfile" 2&>/dev/null
     else
       echo -n '' > "$listfile"
     fi
@@ -268,7 +272,7 @@ $prefix/$app
       fi
       
       echo "${dir};${diricon};:exec "\""echo '${prefix}${dir}/'"\"""
-    done | tee -a "$listfile"
+    done | tee -a "$listfile" 2&>/dev/null
     
     for app in $APPS
     do
@@ -278,7 +282,11 @@ $prefix/$app
         #status file missing - app has never been installed
         echo "${app};${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
       fi
-    done | tee -a "$listfile"
+    done | tee -a "$listfile" 2&>/dev/null
+
+    # write to the pipe all at once instead of in breaking chunks. this prevents errors when user clicks the back button too quickly when the list file is still generating
+    cat "$listfile"
+    echo "Finished preload for $prefix" 1>&2
     
   fi
   

--- a/preload
+++ b/preload
@@ -157,7 +157,7 @@ if [ $reloadlist == 1 ];then
   DIRS="$(grep '/' <<<"$vfiles" | tr -d '/' | grep -vFx "hidden")"
   
   #shuffle the list if enabled
-  if [ "$(cat "${DIRECTORY}/data/settings/Shuffle App list")" == 'Yes' ];then
+  if [ "$(while read line; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/settings/Shuffle App list")" == 'Yes' ];then
     APPS="$(echo "$APPS" | shuf)"
     DIRS="$(echo "$DIRS" | shuf)"
   fi
@@ -209,7 +209,7 @@ $text_color"
     for app in $APPS
     do
       #get installation status of app
-      status="$(cat "${DIRECTORY}/data/status/${app}" 2>/dev/null)"
+      status="$(while read line ; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/status/${app}")"
       
       #determine app icon
       if [ -f "${DIRECTORY}/apps/${app}/icon-24.png" ];then
@@ -220,13 +220,15 @@ $text_color"
       
       #rest of list attributes
       if [ -z "$status" ];then
+        read -r 2>/dev/null line <"${DIRECTORY}/apps/Discord/description" || line="Description unavailable"
         add+="$app
 $prefix/$app
-$(head -n1 "${DIRECTORY}/apps/${app}/description" || echo "Description unavailable")"$'\n'
+$line"$'\n'
       else
+        read -r 2>/dev/null line <"${DIRECTORY}/apps/Discord/description" || line="Description unavailable"
         add+="$app
 $prefix/$app
-"\("$status"\)" $(head -n1 "${DIRECTORY}/apps/${app}/description" || echo "Description unavailable")"$'\n'
+"\("$status"\)" $line"$'\n'
       fi
       
       #determine status text-color for app name (green for installed, red for uninstalled, yellow for corrupted)
@@ -281,7 +283,7 @@ $prefix/$app
     for app in $APPS
     do
       if [ -f "${DIRECTORY}/data/status/${app}" ];then
-        echo "${app} ($(cat "${DIRECTORY}/data/status/${app}" 2>/dev/null));${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
+        echo "${app} ($(while read line; do echo $line; done 2>/dev/null < "${DIRECTORY}/data/status/${app}" 2>/dev/null));${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
       else
         #status file missing - app has never been installed
         echo "${app};${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""

--- a/preload
+++ b/preload
@@ -143,7 +143,7 @@ if [ $reloadlist == 1 ];then
     echo "Showing apps within $prefix/" 1>&2
     vfiles="$(app_prefix_category "$prefix" | grep . | sort -f | uniq | sed "s+$prefix/++g")" #generate a virtual file system with apps in folders represented as subdirectories
   else
-    vfiles="$(app_categories | grep . | sort -f | uniq | grep -v '^hidden/')"
+    vfiles="$(app_prefix_category "" | grep . | sort -f | uniq | grep -v '^hidden/')"
   fi
   
   #remove apps within categories - show this layer of stuff only.

--- a/preload
+++ b/preload
@@ -135,14 +135,14 @@ fi
 if [ $reloadlist == 1 ];then
   echo "Generating list for '$prefix'..." 1>&2
   
-  #for app_categories() and app_status() functions
-  if ! command -v app_categories >/dev/null ;then
+  #for app_prefix_categories() and app_status() functions
+  if ! command -v app_prefix_category >/dev/null ;then
     source "${DIRECTORY}/api"
   fi
   
   if [ ! -z "$prefix" ];then
     echo "Showing apps within $prefix/" 1>&2
-    vfiles="$(app_categories | grep . | sort -f | uniq | grep "^$prefix/" | sed "s+$prefix/++g")" #generate a virtual file system with apps in folders represented as subdirectories
+    vfiles="$(app_prefix_category "$prefix" | grep . | sort -f | uniq | sed "s+$prefix/++g")" #generate a virtual file system with apps in folders represented as subdirectories
   else
     vfiles="$(app_categories | grep . | sort -f | uniq)"
   fi

--- a/preload
+++ b/preload
@@ -164,6 +164,8 @@ if [ $reloadlist == 1 ];then
   
   if [ "$format" == yad ];then
     IFS=$'\n'
+
+    listfile_tmp="$listfile-$(mktemp -u | sed 's:/tmp/tmp.::g')"
     
     #initial value of listfile: if within a prefix, start with a Back button
     if [ ! -z "$prefix" ];then
@@ -171,9 +173,9 @@ if [ $reloadlist == 1 ];then
 Back
 $(dirname "$prefix" | sed 's+^\.$++g')/
 Return to the previous location
-$text_color" | tee "$listfile" 2&>/dev/null
+$text_color" | tee "$listfile_tmp" 2&>/dev/null
     else
-      echo -n '' > "$listfile"
+      echo -n '' > "$listfile_tmp"
     fi
     
     for dir in $DIRS
@@ -200,7 +202,7 @@ $dir/
 $text_color"
       fi
       echo "$add"
-    done | sed 's/&/&amp;/g' | tee -a "$listfile" 2&>/dev/null
+    done | sed 's/&/&amp;/g' | tee -a "$listfile_tmp" 2&>/dev/null
     #finished preloading categories
     
     #preload apps
@@ -244,21 +246,24 @@ $prefix/$app
       fi
       #output finished app lines
       echo "$add"
-    done | sed 's/&/&amp;/g' | tee -a "$listfile" 2&>/dev/null
+    done | sed 's/&/&amp;/g' | tee -a "$listfile_tmp" 2&>/dev/null
 
     # write to the pipe all at once instead of in breaking chunks. this prevents errors when user clicks the back button too quickly when the list file is still generating
+    mv "$listfile_tmp" "$listfile"
     cat "$listfile"
     echo "Finished preload for $prefix" 1>&2
     #finished preloading apps
     
   elif [ "$format" == xlunch ];then
     #XLUNCH list format
+
+    listfile_tmp="$listfile-$(mktemp -u | sed 's:/tmp/tmp.::g')"
     
     #initial value of listfile: if within a prefix, start with a Back button, or if on main page start with Updates
     if [ ! -z "$prefix" ];then
-      echo "Back;${DIRECTORY}/icons/back-64.png;:exec "\""echo /"\""" | tee "$listfile" 2&>/dev/null
+      echo "Back;${DIRECTORY}/icons/back-64.png;:exec "\""echo /"\""" | tee "$listfile_tmp" 2&>/dev/null
     else
-      echo -n '' > "$listfile"
+      echo -n '' > "$listfile_tmp"
     fi
     
     IFS=$'\n'
@@ -271,7 +276,7 @@ $prefix/$app
       fi
       
       echo "${dir};${diricon};:exec "\""echo '${prefix}${dir}/'"\"""
-    done | tee -a "$listfile" 2&>/dev/null
+    done | tee -a "$listfile_tmp" 2&>/dev/null
     
     for app in $APPS
     do
@@ -281,9 +286,10 @@ $prefix/$app
         #status file missing - app has never been installed
         echo "${app};${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
       fi
-    done | tee -a "$listfile" 2&>/dev/null
+    done | tee -a "$listfile_tmp" 2&>/dev/null
 
     # write to the pipe all at once instead of in breaking chunks. this prevents errors when user clicks the back button too quickly when the list file is still generating
+    mv "$listfile_tmp" "$listfile"    
     cat "$listfile"
     echo "Finished preload for $prefix" 1>&2
     

--- a/preload
+++ b/preload
@@ -201,7 +201,7 @@ $dir/
 $text_color"
       fi
       echo "$add"
-    done | sed 's/&/&amp;/g' | tee -a "$listfile_tmp" 2&>/dev/null
+    done | sed 's/&/&amp;/g' >> "$listfile_tmp"
     #finished preloading categories
     
     #preload apps
@@ -247,7 +247,7 @@ $prefix/$app
       fi
       #output finished app lines
       echo "$add"
-    done | sed 's/&/&amp;/g' | tee -a "$listfile_tmp" 2&>/dev/null
+    done | sed 's/&/&amp;/g' >> "$listfile_tmp"
 
     # write to the pipe all at once instead of in breaking chunks. this prevents errors when user clicks the back button too quickly when the list file is still generating
     mv "$listfile_tmp" "$listfile"
@@ -278,7 +278,7 @@ $prefix/$app
       fi
       
       echo "${dir};${diricon};:exec "\""echo '${prefix}${dir}/'"\"""
-    done | tee -a "$listfile_tmp" 2&>/dev/null
+    done >> "$listfile_tmp"
     
     for app in $APPS
     do
@@ -288,7 +288,7 @@ $prefix/$app
         #status file missing - app has never been installed
         echo "${app};${DIRECTORY}/apps/${app}/icon-64.png;:exec "\""echo '$prefix/${app}'"\"""
       fi
-    done | tee -a "$listfile_tmp" 2&>/dev/null
+    done >> "$listfile_tmp"
 
     # write to the pipe all at once instead of in breaking chunks. this prevents errors when user clicks the back button too quickly when the list file is still generating
     mv "$listfile_tmp" "$listfile"

--- a/preload
+++ b/preload
@@ -209,6 +209,7 @@ $text_color"
     for app in $APPS
     do
       #get installation status of app
+      unset status
       read -r 2>/dev/null status <"${DIRECTORY}/data/status/${app}"
       
       #determine app icon


### PR DESCRIPTION
if the lists timestamps do not match, the list generation is done at the time the user clicks on the category. previously, each line of the list was directly echoed to the pipe, meaning if the user clicked the back button, they could send data at the same time that other data was still loading in.

change it so that all data is generated and then read the list file into the pipe at the very end.