### PR TITLE
fix min updater

### DIFF
--- a/.github/workflows/updates/Min.sh
+++ b/.github/workflows/updates/Min.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 webVer=$(get_release minbrowser/min)
-armhf_url="https://github.com/minbrowser/min/releases/download/v${webVer}/min_${webVer}_armhf.deb"
-arm64_url="https://github.com/minbrowser/min/releases/download/v${webVer}/min_${webVer}_arm64.deb"
+armhf_url="https://github.com/minbrowser/min/releases/download/v${webVer}/min-${webVer}-armhf.deb"
+arm64_url="https://github.com/minbrowser/min/releases/download/v${webVer}/min-${webVer}-arm64.deb"
 
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh

--- a/.github/workflows/updates/Min.sh
+++ b/.github/workflows/updates/Min.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 webVer=$(get_release minbrowser/min)
-armhf_url="https://github.com/minbrowser/min/releases/download/v${webVer}/min_${webVer}_armhf.deb"
-arm64_url="https://github.com/minbrowser/min/releases/download/v${webVer}/min_${webVer}_arm64.deb"
+armhf_url="https://github.com/minbrowser/min/releases/download/v${webVer}/Min_${webVer}_armhf.deb"
+arm64_url="https://github.com/minbrowser/min/releases/download/v${webVer}/Min_${webVer}_arm64.deb"
 
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh

--- a/.github/workflows/updates/Min.sh
+++ b/.github/workflows/updates/Min.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 webVer=$(get_release minbrowser/min)
-armhf_url="https://github.com/minbrowser/min/releases/download/v${webVer}/Min_${webVer}_armhf.deb"
-arm64_url="https://github.com/minbrowser/min/releases/download/v${webVer}/Min_${webVer}_arm64.deb"
+armhf_url="https://github.com/minbrowser/min/releases/download/v${webVer}/min_${webVer}_armhf.deb"
+arm64_url="https://github.com/minbrowser/min/releases/download/v${webVer}/min_${webVer}_arm64.deb"
 
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh

--- a/apps/Min/install-32
+++ b/apps/Min/install-32
@@ -2,5 +2,5 @@
 
 version=1.24.0
 
-install_packages https://github.com/minbrowser/min/releases/download/v${version}/min_${version}_armhf.deb || exit 1
+install_packages https://github.com/minbrowser/min/releases/download/v${version}/Min_${version}_armhf.deb || exit 1
 

--- a/apps/Min/install-32
+++ b/apps/Min/install-32
@@ -2,5 +2,5 @@
 
 version=1.25.0
 
-install_packages https://github.com/minbrowser/min/releases/download/v${version}/min_${version}_armhf.deb || exit 1
+install_packages https://github.com/minbrowser/min/releases/download/v${version}/min-${version}-armhf.deb || exit 1
 

--- a/apps/Min/install-32
+++ b/apps/Min/install-32
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=1.24.0
+version=1.25.0
 
-install_packages https://github.com/minbrowser/min/releases/download/v${version}/Min_${version}_armhf.deb || exit 1
+install_packages https://github.com/minbrowser/min/releases/download/v${version}/min_${version}_armhf.deb || exit 1
 

--- a/apps/Min/install-64
+++ b/apps/Min/install-64
@@ -2,5 +2,5 @@
 
 version=1.24.0
 
-install_packages https://github.com/minbrowser/min/releases/download/v${version}/min_${version}_arm64.deb || exit 1
+install_packages https://github.com/minbrowser/min/releases/download/v${version}/Min_${version}_arm64.deb || exit 1
 

--- a/apps/Min/install-64
+++ b/apps/Min/install-64
@@ -2,5 +2,5 @@
 
 version=1.25.0
 
-install_packages https://github.com/minbrowser/min/releases/download/v${version}/min_${version}_arm64.deb || exit 1
+install_packages https://github.com/minbrowser/min/releases/download/v${version}/min-${version}-arm64.deb || exit 1
 

--- a/apps/Min/install-64
+++ b/apps/Min/install-64
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=1.24.0
+version=1.25.0
 
-install_packages https://github.com/minbrowser/min/releases/download/v${version}/Min_${version}_arm64.deb || exit 1
+install_packages https://github.com/minbrowser/min/releases/download/v${version}/min_${version}_arm64.deb || exit 1
 


### PR DESCRIPTION
A prerelease on the upstream min repo was released the other day, noting changes to packaging (the M is simply capitalized in the deb name now): https://github.com/minbrowser/min/releases/tag/v1.25.0-beta

I will be keeping an eye on upstream min releases and will merge this for its next stable release.