### PR TITLE
Eliminate unnecessary bitly calls in pi-apps client to improve accurate user-counts

### DIFF
--- a/manage
+++ b/manage
@@ -624,7 +624,7 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
   #if app succeeded
   if [ $exitcode == 0 ];then
     
-    #Contribute to app install count
+    #Contribute to app install/uninstall count
     if [ $updating == 0 ];then
       bitly_link "$app" "$action" &
     fi

--- a/manage
+++ b/manage
@@ -622,8 +622,9 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
   #if app succeeded
   if [ $exitcode == 0 ];then
     
-    #Contribute to app install/uninstall count
-    if [[ "$4" != "no-bitly" ]];then
+    #Contribute to app install/uninstall count as long as parent processes is NOT updater (during an app-reinstall)
+    #See: https://askubuntu.com/a/1012236
+    if [ $(cat /proc/$PPID/comm) != updater ];then
       bitly_link "$app" "$action" &
     fi
     

--- a/manage
+++ b/manage
@@ -624,7 +624,7 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
     
     #Contribute to app install/uninstall count as long as parent processes is NOT updater (during an app-reinstall)
     #See: https://askubuntu.com/a/1012236
-    if [ $(cat /proc/$PPID/comm) != updater ] || [ "$3" == "update" ];then
+    if [ $(cat /proc/$PPID/comm) != updater ];then
       bitly_link "$app" "$action" &
     fi
     

--- a/manage
+++ b/manage
@@ -592,9 +592,6 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
     done
   fi
   
-  #analytics
-  bitly_link "$app" "$action" &
-  
   #if this app has scripts, determine which script to run
   if [ "$(app_type "$app")" == standard ];then
     if [ "$action" == install ];then
@@ -615,8 +612,10 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
   echo
   cd $HOME
   if [[ "$3" == "update" ]]; then
+    updating=1
     script_input="update"
   else
+    updating=0
     script_input=""
   fi
   nice "${appscript[@]}" "$script_input" &> >(tee -a "$logfile")
@@ -624,6 +623,12 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
   
   #if app succeeded
   if [ $exitcode == 0 ];then
+    
+    #Contribute to app install count
+    if [ $updating == 0 ];then
+      bitly_link "$app" "$action" &
+    fi
+    
     status_green "\n${action^}ed ${app} successfully." | tee -a "$logfile"
     echo "${action}ed" > "${DIRECTORY}/data/status/${app}"
     

--- a/manage
+++ b/manage
@@ -624,7 +624,7 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
     
     #Contribute to app install/uninstall count as long as parent processes is NOT updater (during an app-reinstall)
     #See: https://askubuntu.com/a/1012236
-    if [ $(cat /proc/$PPID/comm) != updater ];then
+    if [ "$(cat /proc/$PPID/comm)" != "updater" ] && [ "$3" != "update" ];then
       bitly_link "$app" "$action" &
     fi
     

--- a/manage
+++ b/manage
@@ -611,7 +611,7 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
   status "${action^}ing \e[1m${app}\e[0m\e[96m..." | tee -a "$logfile"
   echo
   cd $HOME
-  if [[ "$3" == "update" ]]; then
+  if [ "$3" == "update" ]; then
     script_input="update"
   else
     script_input=""
@@ -624,7 +624,7 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
     
     #Contribute to app install/uninstall count as long as parent processes is NOT updater (during an app-reinstall)
     #See: https://askubuntu.com/a/1012236
-    if [ $(cat /proc/$PPID/comm) != updater ];then
+    if [ $(cat /proc/$PPID/comm) != updater ] || [ "$3" == "update" ];then
       bitly_link "$app" "$action" &
     fi
     

--- a/manage
+++ b/manage
@@ -612,10 +612,8 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
   echo
   cd $HOME
   if [[ "$3" == "update" ]]; then
-    updating=1
     script_input="update"
   else
-    updating=0
     script_input=""
   fi
   nice "${appscript[@]}" "$script_input" &> >(tee -a "$logfile")
@@ -625,7 +623,7 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
   if [ $exitcode == 0 ];then
     
     #Contribute to app install/uninstall count
-    if [ $updating == 0 ];then
+    if [[ "$4" != "no-bitly" ]];then
       bitly_link "$app" "$action" &
     fi
     

--- a/updater
+++ b/updater
@@ -393,7 +393,7 @@ update_app() { #first word is app name
   
   if [ "$installback" == 'yes' ];then
     #install the app again
-    "${DIRECTORY}/manage" install "$app"
+    "${DIRECTORY}/manage" install "$app" update #report to the app uninstall script that this is an uninstall for the purpose of updating by passing "update"
     if [ $? != 0 ]; then
       failed=true
     fi

--- a/updater
+++ b/updater
@@ -375,7 +375,7 @@ update_app() { #first word is app name
     installback=yes
     status "$app's install script has been updated. Reinstalling $app..."
     #uninstall it
-    "${DIRECTORY}/manage" uninstall "$app" update #report to the app uninstall script that this is an uninstall for the purpose of updating by passing "update"
+    "${DIRECTORY}/manage" uninstall "$app" update no-bitly #report to the app uninstall script that this is an uninstall for the purpose of updating by passing "update"
     
     #fix edge case: if app is installed but uninstall script doesn't exist somehow, then pretend app was uninstalled so that the reinstall later will happen noninteractively
     if [ "$(app_status "$app")" == installed ];then
@@ -393,7 +393,7 @@ update_app() { #first word is app name
   
   if [ "$installback" == 'yes' ];then
     #install the app again
-    "${DIRECTORY}/manage" install "$app" update #report to the app install script that this is an install for the purpose of updating by passing "update"
+    "${DIRECTORY}/manage" install "$app" update no-bitly #report to the app install script that this is an install for the purpose of updating by passing "update"
     if [ $? != 0 ]; then
       failed=true
     fi

--- a/updater
+++ b/updater
@@ -393,7 +393,7 @@ update_app() { #first word is app name
   
   if [ "$installback" == 'yes' ];then
     #install the app again
-    "${DIRECTORY}/manage" install "$app" update #report to the app uninstall script that this is an uninstall for the purpose of updating by passing "update"
+    "${DIRECTORY}/manage" install "$app" update #report to the app install script that this is an install for the purpose of updating by passing "update"
     if [ $? != 0 ]; then
       failed=true
     fi

--- a/updater
+++ b/updater
@@ -375,7 +375,7 @@ update_app() { #first word is app name
     installback=yes
     status "$app's install script has been updated. Reinstalling $app..."
     #uninstall it
-    "${DIRECTORY}/manage" uninstall "$app" update no-bitly #report to the app uninstall script that this is an uninstall for the purpose of updating by passing "update"
+    "${DIRECTORY}/manage" uninstall "$app" update #report to the app uninstall script that this is an uninstall for the purpose of updating by passing "update"
     
     #fix edge case: if app is installed but uninstall script doesn't exist somehow, then pretend app was uninstalled so that the reinstall later will happen noninteractively
     if [ "$(app_status "$app")" == installed ];then
@@ -393,7 +393,7 @@ update_app() { #first word is app name
   
   if [ "$installback" == 'yes' ];then
     #install the app again
-    "${DIRECTORY}/manage" install "$app" update no-bitly #report to the app install script that this is an install for the purpose of updating by passing "update"
+    "${DIRECTORY}/manage" install "$app" update #report to the app install script that this is an install for the purpose of updating by passing "update"
     if [ $? != 0 ]; then
       failed=true
     fi


### PR DESCRIPTION
With this PR, the bitly link is clicked ONLY if the app is successfully installed/uninstalled, *and* if it's not being reinstalled during an update.