### PR TITLE
highly optimized set-status function depends

### DIFF
--- a/gui
+++ b/gui
@@ -317,7 +317,7 @@ generate_logo &
 
 #install dependencies
 runonce <<"EOF"
-  dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils'
+  dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils rsync'
   # Install dependencies if necessary
   if ! dpkg -s $dependencies >/dev/null 2>&1; then
     sudo_popup apt install $dependencies -y -f --no-install-recommends

--- a/install
+++ b/install
@@ -23,7 +23,7 @@ fi
 sudo apt update || error "The command 'sudo apt update' failed. Before Pi-Apps will work, you must fix your apt package-management system."
 
 #install dependencies
-dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils'
+dependencies='yad curl wget aria2 lsb-release apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils rsync'
 
 if ! dpkg -s $dependencies &>/dev/null ;then
   sudo apt install $dependencies -y -f --no-install-recommends

--- a/updater
+++ b/updater
@@ -489,6 +489,16 @@ if [ "$runmode" == autostarted ];then #if update-interval allows, and one app in
   updatable_apps="$(get_updatable_apps)"
   updatable_files="$(get_updatable_files)"
 
+  #write to updatable-apps file only if something was changed
+  if [ "$updatable_apps" != "$(cat "${DIRECTORY}/data/update-status/updatable-apps")" ];then
+    echo "$updatable_apps" | grep . > "${DIRECTORY}/data/update-status/updatable-apps"
+  fi
+  
+  #write to updatable-files file only if something was changed
+  if [ "$updatable_files" != "$(cat "${DIRECTORY}/data/update-status/updatable-files")" ];then
+    echo "$updatable_files" | grep . > "${DIRECTORY}/data/update-status/updatable-files"
+  fi
+
   if [ -z "$updatable_files" ] && [ -z "$updatable_apps" ];then
     status "Nothing is updatable."
     exit 0
@@ -541,7 +551,6 @@ if [ "$runmode" == autostarted ];then #if update-interval allows, and one app in
   list_updates_gui
   if [ -z "$updatable_files" ] && [ -z "$updatable_apps" ];then
     status "User did not allow anything to be updated."
-    "${DIRECTORY}/updater" set-status
     exit 0
   fi
   

--- a/updater
+++ b/updater
@@ -541,6 +541,7 @@ if [ "$runmode" == autostarted ];then #if update-interval allows, and one app in
   list_updates_gui
   if [ -z "$updatable_files" ] && [ -z "$updatable_apps" ];then
     status "User did not allow anything to be updated."
+    "${DIRECTORY}/updater" set-status
     exit 0
   fi
   
@@ -553,6 +554,7 @@ if [ "$runmode" == autostarted ];then #if update-interval allows, and one app in
     --image="${DIRECTORY}/icons/logo-64.png" \
     --button="Close!${DIRECTORY}/icons/exit.png":1 \
     --timeout=30
+  "${DIRECTORY}/updater" set-status
   
 elif [ "$runmode" == 'get-status' ];then #Check if anything was deemed updatable the last time updates were checked for.
   

--- a/updater
+++ b/updater
@@ -119,30 +119,7 @@ get_updatable_files() { #sets the updatable_files variable
     
   else #speed was not set to 'fast', so compare each file to the one in the update folder
     echo -n "Scanning files... " 1>&2
-    
-    #get list of pi-apps files without absolute paths. Example line: 'etc/terminal-run'
-    local file_list="$(list_files)" || exit 1
-    
-    local updatable_files='' #the variable to be returned
-    local IFS=$'\n'
-    for file in $file_list ;do
-      
-      echo -en "Scanning files... $file\e[0K\r" 1>&2
-      if [ ! -f "${DIRECTORY}/${file}" ];then
-        #file is missing locally - add to updatable_files list
-        updatable_files+=$'\n'"${file}"
-        
-      elif [ ! -f "${DIRECTORY}/update/pi-apps/${file}" ];then
-        #file is missing in the update folder - local
-        true #do not add to updatable_apps list
-        
-      elif ! diff "${DIRECTORY}/update/pi-apps/${file}" "${DIRECTORY}/${file}" -q >/dev/null ;then
-        #files don't match - add to updatable_files list
-        updatable_files+=$'\n'"${file}"
-      fi
-    done
-    #remove initial newline character
-    updatable_files="${updatable_files:1}"
+    updatable_files=$(rsync --exclude="/apps/" --exclude="/.git/" --exclude="/.github/" --exclude="/data/" -ric --dry-run --out-format="%n" "${DIRECTORY}/update/pi-apps/" "${DIRECTORY}/")
   fi
   
   #If an updatable file is listed in update-exclusion, remove it from list and save notification text for later.
@@ -165,27 +142,13 @@ get_updatable_apps() { #return a list of updatable apps
   if [ "$speed" == fast ] && [ -f "${DIRECTORY}/data/update-status/updatable-apps" ];then
     #speed is set to 'fast' - don't hash anything but rely on past results
     local updatable_apps="$(cat "${DIRECTORY}/data/update-status/updatable-apps")"
-    
-  else #compare each file to the one in the update folder
-    local updatable_apps=''
-    local IFS=$'\n'
-    for app in $(list_apps online)
-    do
-      echo -en "Scanning apps... $app\e[0K\r" 1>&2
-      
-      if [ ! -d "${DIRECTORY}/apps/${app}" ];then
-        #if app is missing locally, add to updatable list
-        updatable_apps+=$'\n'"${app}"
-        
-      elif ! diff -r "${DIRECTORY}/apps/${app}" "${DIRECTORY}/update/pi-apps/apps/${app}" -q >/dev/null ;then
-        #if app-folder contents don't match, add to updatable list
-        updatable_apps+=$'\n'"${app}"
-      fi
-    done
-    updatable_apps="${updatable_apps:1}" #remove initial newline character
+    echo "$updatable_apps"
+  else #compare all apps to the ones in the update folder
+    # requires english locale to be properly enabled and for diff naming convention not to change
+    #diff -rq "${DIRECTORY}/apps" "${DIRECTORY}/update/pi-apps/apps" | sed "\|^Only in ${DIRECTORY}/apps|d" | sed "s;Only in ${DIRECTORY}/update/pi-apps/apps: ;;g" | sed "s;Files ${DIRECTORY}/apps/;;g" | awk -F '/' '{print $1}' | uniq
+    # same output, but with rsync which is much simpler. slightly slower
+    rsync -ric --dry-run --out-format="%n" "${DIRECTORY}/update/pi-apps/apps/" "${DIRECTORY}/apps/" | awk -F '/' '{print $1}' | uniq
   fi
-  echo -e "Scanning apps... Done\e[0K" 1>&2
-  echo "$updatable_apps"
 }
 
 generate_yad_list() { #input: updatable_apps and updatable_files variables

--- a/updater
+++ b/updater
@@ -111,15 +111,43 @@ list_files() { #list all files on pi-apps with relative paths - both on main dir
   cd $HOME
 }
 
-get_updatable_files() { #sets the updatable_files variable
+get_updatable_files() { #returns a list of updatable files
+  local updatable_files=''
   
   if [ "$speed" == fast ] && [ -f "${DIRECTORY}/data/update-status/updatable-files" ];then
     #speed is set to 'fast' - don't hash anything but rely on past results
-    local updatable_files="$(cat "${DIRECTORY}/data/update-status/updatable-files")"
+    updatable_files="$(cat "${DIRECTORY}/data/update-status/updatable-files")"
     
   else #speed was not set to 'fast', so compare each file to the one in the update folder
     echo -n "Scanning files... " 1>&2
-    updatable_files=$(rsync --exclude="/apps/" --exclude="/.git/" --exclude="/.github/" --exclude="/data/" -ric --dry-run --out-format="%n" "${DIRECTORY}/update/pi-apps/" "${DIRECTORY}/")
+    
+    #Use rsync for faster speed, if available
+    if command -v rsync >/dev/null ;then
+      updatable_files="$(rsync --exclude="/apps/" --exclude="/.git/" --exclude="/.github/" --exclude="/data/" -ric --dry-run --out-format="%n" "${DIRECTORY}/update/pi-apps/" "${DIRECTORY}/")"
+    else
+      #get list of pi-apps files without absolute paths. Example line: 'etc/terminal-run'
+      local file_list="$(list_files)" || exit 1
+      
+      local IFS=$'\n'
+      for file in $file_list ;do
+        
+        echo -en "Scanning files... $file\e[0K\r" 1>&2
+        if [ ! -f "${DIRECTORY}/${file}" ];then
+          #file is missing locally - add to updatable_files list
+          updatable_files+=$'\n'"${file}"
+          
+        elif [ ! -f "${DIRECTORY}/update/pi-apps/${file}" ];then
+          #file is missing in the update folder - local
+          true #do not add to updatable_apps list
+          
+        elif ! diff "${DIRECTORY}/update/pi-apps/${file}" "${DIRECTORY}/${file}" -q >/dev/null ;then
+          #files don't match - add to updatable_files list
+          updatable_files+=$'\n'"${file}"
+        fi
+      done
+      #remove initial newline character
+      updatable_files="${updatable_files:1}"
+    fi
   fi
   
   #If an updatable file is listed in update-exclusion, remove it from list and save notification text for later.
@@ -138,17 +166,39 @@ get_updatable_files() { #sets the updatable_files variable
 }
 
 get_updatable_apps() { #return a list of updatable apps
+  local updatable_apps=''
   
   if [ "$speed" == fast ] && [ -f "${DIRECTORY}/data/update-status/updatable-apps" ];then
     #speed is set to 'fast' - don't hash anything but rely on past results
-    local updatable_apps="$(cat "${DIRECTORY}/data/update-status/updatable-apps")"
-    echo "$updatable_apps"
+    cat "${DIRECTORY}/data/update-status/updatable-apps"
   else #compare all apps to the ones in the update folder
-    # requires english locale to be properly enabled and for diff naming convention not to change
-    #diff -rq "${DIRECTORY}/apps" "${DIRECTORY}/update/pi-apps/apps" | sed "\|^Only in ${DIRECTORY}/apps|d" | sed "s;Only in ${DIRECTORY}/update/pi-apps/apps: ;;g" | sed "s;Files ${DIRECTORY}/apps/;;g" | awk -F '/' '{print $1}' | uniq
-    # same output, but with rsync which is much simpler. slightly slower
-    rsync -ric --dry-run --out-format="%n" "${DIRECTORY}/update/pi-apps/apps/" "${DIRECTORY}/apps/" | awk -F '/' '{print $1}' | uniq
+    
+    #Use rsync for faster speed, if available
+    if command -v rsync >/dev/null ;then
+      # requires english locale to be properly enabled and for diff naming convention not to change
+      #diff -rq "${DIRECTORY}/apps" "${DIRECTORY}/update/pi-apps/apps" | sed "\|^Only in ${DIRECTORY}/apps|d" | sed "s;Only in ${DIRECTORY}/update/pi-apps/apps: ;;g" | sed "s;Files ${DIRECTORY}/apps/;;g" | awk -F '/' '{print $1}' | uniq
+      # same output, but with rsync which is much simpler. slightly slower
+      rsync -ric --dry-run --out-format="%n" "${DIRECTORY}/update/pi-apps/apps/" "${DIRECTORY}/apps/" | awk -F '/' '{print $1}' | uniq
+    else
+      local IFS=$'\n'
+      for app in $(list_apps online)
+      do
+        echo -en "Scanning apps... $app\e[0K\r" 1>&2
+
+        if [ ! -d "${DIRECTORY}/apps/${app}" ];then
+          #if app is missing locally, add to updatable list
+          updatable_apps+=$'\n'"${app}"
+
+        elif ! diff -r "${DIRECTORY}/apps/${app}" "${DIRECTORY}/update/pi-apps/apps/${app}" -q >/dev/null ;then
+          #if app-folder contents don't match, add to updatable list
+          updatable_apps+=$'\n'"${app}"
+        fi
+      done
+      updatable_apps="${updatable_apps:1}" #remove initial newline character
+      echo "$updatable_apps"
+    fi
   fi
+  echo -e "Scanning apps... Done\e[0K" 1>&2
 }
 
 generate_yad_list() { #input: updatable_apps and updatable_files variables

--- a/updater
+++ b/updater
@@ -119,12 +119,16 @@ get_updatable_files() { #returns a list of updatable files
     updatable_files="$(cat "${DIRECTORY}/data/update-status/updatable-files")"
     
   else #speed was not set to 'fast', so compare each file to the one in the update folder
-    echo -n "Scanning files... " 1>&2
+    echo -ne "Scanning files... \r" 1>&2
     
     #Use rsync for faster speed, if available
     if command -v rsync >/dev/null ;then
       updatable_files="$(rsync --exclude="/apps/" --exclude="/.git/" --exclude="/.github/" --exclude="/data/" -ric --dry-run --out-format="%n" "${DIRECTORY}/update/pi-apps/" "${DIRECTORY}/")"
-    else
+      false
+    fi
+    
+    if [ $? != 0 ] || ! command -v rsync >/dev/null ;then
+      
       #get list of pi-apps files without absolute paths. Example line: 'etc/terminal-run'
       local file_list="$(list_files)" || exit 1
       
@@ -179,7 +183,9 @@ get_updatable_apps() { #return a list of updatable apps
       #diff -rq "${DIRECTORY}/apps" "${DIRECTORY}/update/pi-apps/apps" | sed "\|^Only in ${DIRECTORY}/apps|d" | sed "s;Only in ${DIRECTORY}/update/pi-apps/apps: ;;g" | sed "s;Files ${DIRECTORY}/apps/;;g" | awk -F '/' '{print $1}' | uniq
       # same output, but with rsync which is much simpler. slightly slower
       rsync -ric --dry-run --out-format="%n" "${DIRECTORY}/update/pi-apps/apps/" "${DIRECTORY}/apps/" | awk -F '/' '{print $1}' | uniq
-    else
+    fi
+    
+    if [ ${PIPESTATUS[0]} != 0 ] || ! command -v rsync >/dev/null ;then
       local IFS=$'\n'
       for app in $(list_apps online)
       do


### PR DESCRIPTION
this is a draft because this introduces a new dependency to pi-apps, `rsync`, which is an extremely helpful tool for moving (and diffing) files.

the purpose of this PR was to reduce runtime of the set-status function so that it beats out the preload call, and hence would show updates in the GUI on launch without switching tabs
```
    (echo -e '\f' > $pipe
    sleep 0.5
    "${DIRECTORY}/preload" yad '' >> $pipe) &
```

unfortunately, set-status calls `git pull` which on my system takes 0.5 seconds regardless of if the local repo matches master or if it has to pull new changes.

the changes to `get_updatable_files` and `get_updatable_apps` greatly optimize running these functions. each one would take approximately 0.5 seconds to run in their entirety since they called diff on each and every file. the new function calls rsync on the entire folder contents which speeds up runtime by 10X and each function now takes 0.05 seconds