### PR TITLE
Make VSCode's deb URL hardcoded

### DIFF
--- a/.github/workflows/updates/Visual Studio Code.sh
+++ b/.github/workflows/updates/Visual Studio Code.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+webVer="$(curl -sLI -o /dev/null -w %{url_effective} https://aka.ms/linux-armhf-deb | grep -o '_.*-' | sed 's/_\|-//g')"
+armhf_url="https://update.code.visualstudio.com/${webVer}/linux-deb-armhf/stable"
+arm64_url="https://update.code.visualstudio.com/${webVer}/linux-deb-arm64/stable"
+
+source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh

--- a/apps/Visual Studio Code/install-32
+++ b/apps/Visual Studio Code/install-32
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-install_packages https://aka.ms/linux-armhf-deb || exit 1
+version=1.68.1
+
+install_packages https://update.code.visualstudio.com/${version}/linux-deb-armhf/stable || exit 1

--- a/apps/Visual Studio Code/install-64
+++ b/apps/Visual Studio Code/install-64
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-install_packages https://aka.ms/linux-arm64-deb || exit 1
+version=1.68.1
+
+install_packages https://update.code.visualstudio.com/${version}/linux-deb-arm64/stable || exit 1


### PR DESCRIPTION
For pi-apps to handle the job of updating VSCode when a new version comes, instead of manually downloading the new version by users.