### PR TITLE
exit pi-apps immediately if run as sudo/root

### DIFF
--- a/gui
+++ b/gui
@@ -9,6 +9,14 @@ if ! command -v yad &>/dev/null; then
   error "YAD needs to be installed to run Pi-Apps."
 fi
 
+if [[ $(id -u) == 0 ]]; then
+  echo "Pi-Apps is not designed to be run as root! Please try again as a regular user." | yad --center --window-icon="${DIRECTORY}/icons/logo.png" \
+  --width=700 --height=300 --text-info --title="Error" \
+  --image="${DIRECTORY}/icons/error.png" --image-on-top --fontname=12 \
+  --button='OK'
+  error "Pi-Apps is not designed to be run as root! Please try again as a regular user."
+fi
+
 # set GUI format versioning
 export GUI_FORMAT_VERSION=2
 

--- a/manage
+++ b/manage
@@ -10,6 +10,10 @@ function error {
   exit 1
 }
 
+if [[ $(id -u) == 0 ]]; then
+  error "Pi-Apps is not designed to be run as root! Please try again as a regular user."
+fi
+
 if [ -z "$1" ];then
   error "You need to specify an operation, and in most cases, which app to operate on."
 fi

--- a/updater
+++ b/updater
@@ -6,6 +6,10 @@ function error {
   exit 1
 }
 
+if [[ $(id -u) == 0 ]]; then
+  error "Pi-Apps is not designed to be run as root! Please try again as a regular user."
+fi
+
 [ -z "$DIRECTORY" ] && DIRECTORY="$(readlink -f "$(dirname "$0")")"
 
 #if being sourced, ensure DIRECTORY variable set


### PR DESCRIPTION
running pi-apps as root can seriously mess up the users install. prevent running the gui, manage, and updater scripts as root.

I have seen cases where users "think" running pi-apps as sudo "fixes" their issues in the discord, when in fact all it does is mess up all the file permissions