### PR TITLE
switch from bitly to shlink

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -384,11 +384,11 @@ End of Flatpak functions. App functions below.
 - `read_category_files` - Generates a list of categories; data compiled from the `data/category-overrides` and `etc/categories` files, with added support for unlisted apps.
 - `app_categories` - Format the categories file, then list all apps, as if they were inside folders, based on the categories file. Also lists all apps under special "Installed" and "All Apps" categories.
 
-- `bitly_link` - Increase/decrease the "number of users" a certain app has.
-  - Botspot creates [bitly](https://bitly.com) links for every app: one link for installing it, and one link for uninstalling it.
-  - Bitly will track how many times each link has been clicked.
+- `shlink_link` - Increase/decrease the "number of users" a certain app has.
+  - A GitHub Actions script creates [shlink](https://shlink.io/) links for every app: one link for installing it, and one link for uninstalling it.
+  - The Pi-Apps server running a shlink instance will track how many times each link has been clicked.
   - Assuming the "Enable Analytics" setting was not turned off, this function will "click" one of those links.
-  - Botspot uses a script to upload bitly's statistics to the [pi-apps-analytics](https://github.com/Botspot/pi-apps-analytics) repository.
+  - Botspot and theofficialgman created a script to upload shlink's statistics to the [pi-apps-analytics](https://github.com/Botspot/pi-apps-analytics) repository.
 - `usercount` - returns the number of users an app has, based on the current number in the [pi-apps-analytics](https://github.com/Botspot/pi-apps-analytics) repository.
   To display the number of users for the Arduino app:
   ```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -385,10 +385,12 @@ End of Flatpak functions. App functions below.
 - `app_categories` - Format the categories file, then list all apps, as if they were inside folders, based on the categories file. Also lists all apps under special "Installed" and "All Apps" categories.
 
 - `shlink_link` - Increase/decrease the "number of users" a certain app has.
-  - A GitHub Actions script creates [shlink](https://shlink.io/) links for every app: one link for installing it, and one link for uninstalling it.
-  - The Pi-Apps server running a shlink instance will track how many times each link has been clicked.
+  - There are two [shlink](https://shlink.io/) links for every app: one link for installing it, and one link for uninstalling it.
   - Assuming the "Enable Analytics" setting was not turned off, this function will "click" one of those links.
-  - Botspot and theofficialgman created a script to upload shlink's statistics to the [pi-apps-analytics](https://github.com/Botspot/pi-apps-analytics) repository.
+  - How this link system works:
+    - A Github Actions [script](https://github.com/Botspot/pi-apps/blob/master/.github/workflows/create_shlink_links.yml) on the main Pi-Apps repository automatically creates install/uninstall shlinks for every new app that is added.
+    - The Pi-Apps server running a shlink instance (at https://analytics.pi-apps.io) will record the number of "clicks" for each link.
+    - Another Github Actions script uploads shlink's statistics to the [pi-apps-analytics](https://github.com/Botspot/pi-apps-analytics) repository, which can then be retrieved by Pi-Apps clients through the `usercount` function, explained below. 
 - `usercount` - returns the number of users an app has, based on the current number in the [pi-apps-analytics](https://github.com/Botspot/pi-apps-analytics) repository.
   To display the number of users for the Arduino app:
   ```

--- a/api
+++ b/api
@@ -840,21 +840,25 @@ app_prefix_category() { #lists all apps in a category with format "category/app"
   fi
 }
 
-bitly_link() { #Runs whenever an app is installed/uninstalled to tally the number of users for each app
+bitly_link() { #compatibility function pointing to shlink_link (incase old manage script is running with new api)
+  shlink_link "$@"
+}
+
+shlink_link() { #Runs whenever an app is installed/uninstalled to tally the number of users for each app
   #This cannot possibly be used to identify you, or any information about you.
-  #It simply "clicks" a bitly link - a shortened URL - so that the total number of clicks can be tallied to determine how popular a certain app is.
+  #It simply "clicks" a shlink link - a shortened URL - so that the total number of clicks can be tallied to determine how popular a certain app is.
   app="$1"
   trigger="$2"
   
-  [ -z "$app" ] && error "bitly_link(): requires an app argument"
-  [ -z "$trigger" ] && error "bitly_link(): requires a trigger argument"
+  [ -z "$app" ] && error "shlink_link(): requires an app argument"
+  [ -z "$trigger" ] && error "shlink_link(): requires a trigger argument"
   
   #if the 'Enable Analytics' setting is enabled
   if [ "$(cat "${DIRECTORY}/data/settings/Enable analytics")" == 'Yes' ];then
     #determine the name of the link to "click"
-    bitlylink="https://bit.ly/pi-apps-$trigger-$(echo "$app" | tr -d ' ' | sed 's/[^a-zA-Z0-9]//g')"
+    shlinklink="https://analytics.pi-apps.io/pi-apps-$trigger-$(echo "$app" | tr -d ' ' | sed 's/[^a-zA-Z0-9]//g')/track"
     #click it
-    curl -L --user-agent "Pi-Apps Raspberry Pi app store" "$bitlylink" &>/dev/null &
+    curl -s -X 'GET' "$shlinklink" -H 'accept: image/gif' -A "Pi-Apps Raspberry Pi app store" >/dev/null &
   fi
 }
 
@@ -1088,7 +1092,7 @@ refresh_pkgapp_status() { #for the specified package-app, if dpkg thinks it's in
     if [ "$(app_status "$app")" != 'installed' ];then
       echo "Marking $app as installed"
       echo 'installed' > "${DIRECTORY}/data/status/${app}"
-      bitly_link "$app" install &
+      shlink_link "$app" install &
     fi
   #if that package is not installed, check if it even exists on the repositories
   elif package_available "$package" ;then
@@ -1096,7 +1100,7 @@ refresh_pkgapp_status() { #for the specified package-app, if dpkg thinks it's in
     if [ "$(app_status "$app")" != 'uninstalled' ];then
       echo "Marking $app as uninstalled"
       rm -f "${DIRECTORY}/data/status/${app}"
-      bitly_link "$app" uninstall &
+      shlink_link "$app" uninstall &
     fi
   else
     #this app is trying to install a package that's not on the repository. Hide the app.

--- a/etc/setting-params/Enable analytics
+++ b/etc/setting-params/Enable analytics
@@ -1,5 +1,5 @@
 #Analytics are used to count the number of installs for each app.
-#Each app is associated with a bit.ly link. During an install, that link is "clicked". The total number of clicks is used to calculate how many users each app has.
+#Each app is associated with a shlink link. During an install, that link is "clicked". The total number of clicks is used to calculate how many users each app has.
 #This information cannot possibly be used to identify you, or any personal information about you.
 Yes
 No

--- a/manage
+++ b/manage
@@ -629,7 +629,7 @@ elif [ "$1" == 'install' ] || [ "$1" == 'uninstall' ];then
     #Contribute to app install/uninstall count as long as parent processes is NOT updater (during an app-reinstall)
     #See: https://askubuntu.com/a/1012236
     if [ "$(cat /proc/$PPID/comm)" != "updater" ] && [ "$3" != "update" ];then
-      bitly_link "$app" "$action" &
+      shlink_link "$app" "$action" &
     fi
     
     status_green "\n${action^}ed ${app} successfully." | tee -a "$logfile"


### PR DESCRIPTION
keep bitly_link function and point it to shlink_link incase an old instance of the manage script is still running with the new api sourced

I would like this to stay as a draft until I can see shlink results in the pi-apps-analytics repo for all apps. that will take 1-2 days

(edit: force pushed to add relevant co-authors for this change)