### PR TITLE
Use `HOME` variable instead of `/home/pi` in CommanderPi description

### DIFF
--- a/apps/CommanderPi/description
+++ b/apps/CommanderPi/description
@@ -1,4 +1,4 @@
 Easy RaspberryPi4 GUI system management
 Using CommanderPi, you can change overclock settings, bootloader settings, switch kernels, and view performance diagnostics.
 To run: Menu -> Accessories -> CommanderPi
-To run in a terminal: $HOME/CommanderPi/src/start.sh
+To run in a terminal: ~/CommanderPi/src/start.sh

--- a/apps/CommanderPi/description
+++ b/apps/CommanderPi/description
@@ -1,4 +1,4 @@
-Easy RaspberryPi4 GUI system managment
+Easy RaspberryPi4 GUI system management
 Using CommanderPi, you can change overclock settings, bootloader settings, switch kernels, and view performance diagnostics.
 To run: Menu -> Accessories -> CommanderPi
-To run in a terminal: /home/pi/CommanderPi/src/start.sh
+To run in a terminal: $HOME/CommanderPi/src/start.sh


### PR DESCRIPTION
Users with different usernames can directly copy the command from the description and paste it into the terminal.