### PR TITLE
Bump BlockBench to 4.4.3-391

### DIFF
--- a/apps/BlockBench/install-32
+++ b/apps/BlockBench/install-32
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=4.4.2-390
+version=4.4.3-391
 
 install_packages https://apt.raspbian-addons.org/debian/pool/main/b/blockbench/blockbench_${version}_armhf.deb || exit 1
 

--- a/apps/BlockBench/install-64
+++ b/apps/BlockBench/install-64
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=4.4.2-390
+version=4.4.3-391
 
 install_packages https://apt.raspbian-addons.org/debian/pool/main/b/blockbench/blockbench_${version}_arm64.deb || exit 1
 


### PR DESCRIPTION
It's been a long time since I've touched the codebase and i'm not sure how the automatic updating bot works, so I'm opening this PR just in case. Please close if this is to be handled by the bot!