### PR TITLE
Update webapp-manager to v1.2.5

### DIFF
--- a/apps/Web Apps/install-32
+++ b/apps/Web Apps/install-32
@@ -1,10 +1,10 @@
 #!/bin/bash
 rm -rf ~/Linux_Mint_Webapps || error "Failed to delete Linux_Mint_Webapps folder for some reason."
-git_clone https://github.com/phoenixbyrd/Linux_Mint_Webapps || error 'Failed to clone phoenixbyrd web apps repository!'
+git_clone https://github.com/Rak1ta/Linux_Mint_Webapps || error 'Failed to clone phoenixbyrd web apps repository!'
 cd Linux_Mint_Webapps || error 'Failed to enter directory!'
 
 # Get dependencies
-install_packages $(pwd)/xapps-common_2.0.7-1_all.deb $(pwd)/libxapp1_2.0.7-1_armhf.deb $(pwd)/gir1.2-xapp-1.0_2.0.7-1_armhf.deb $(pwd)/libxapp-dev_2.0.7-1_armhf.deb $(pwd)/libxapp1-dbgsym_2.0.7-1_armhf.deb devhelp $(pwd)/webapp-manager_1.1.1_all.deb || exit 1
+install_packages $(pwd)/xapps-common_2.0.7-1_all.deb $(pwd)/libxapp1_2.0.7-1_armhf.deb $(pwd)/gir1.2-xapp-1.0_2.0.7-1_armhf.deb $(pwd)/libxapp-dev_2.0.7-1_armhf.deb $(pwd)/libxapp1-dbgsym_2.0.7-1_armhf.deb devhelp $(pwd)/webapp-manager_1.2.5_all.deb || exit 1
 #remove folder
 cd $HOME
 rm -rf ~/Linux_Mint_Webapps || error "Failed to delete Linux_Mint_Webapps folder for some reason."


### PR DESCRIPTION
The original [repository](https://github.com/linuxmint/webapp-manager) has had a lot of app updates lately. Notable improvements include the Vivaldi Browser/Chromium Snap and the ability to launch a window in incognito mode. The repo from [phoenixbyrd](https://github.com/phoenixbyrd/Linux_Mint_Webapps) hasn't changed in two years and I made a fork so I can upgrade quickly. Followed this [instruction](https://github.com/hsbasu/webapp-manager/blob/80fc68a13d5c9ce0f224a80788673b1cffe811a4/README.md).