### PR TITLE
use theofficialgman install based neofetch fork

### DIFF
--- a/apps/Neofetch/credits
+++ b/apps/Neofetch/credits
@@ -1,3 +1,2 @@
 App Credit: dylanaraps - (GitHub: https://github.com/dylanaraps)
-
-Added to Pi-Apps by nikoloiz - (GitHub: https://github.com/nikoloiz)
+Patches: theofficialgman

--- a/apps/Neofetch/description
+++ b/apps/Neofetch/description
@@ -1,3 +1,5 @@
 An aesthetically pleasing bash script to show system information.
 
 To run in terminal: 'neofetch'
+
+This version of Neofetch is better than what can be found by default from APT. It correctly detects CPU and GPU info on ARM systems - details which are hidden in the official version.

--- a/apps/Neofetch/install
+++ b/apps/Neofetch/install
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+#remove neofetch package first
+if package_installed neofetch ;then
+  echo "Removing neofetch package first..."
+  apt_lock_wait
+  sudo apt purge -y --autoremove neofetch
+fi
+
+install_packages make pciutils mesa-utils || exit 1
+
+cd /tmp || error "Could not move to /tmp folder"
+rm -rf /tmp/neofetch
+git clone --branch merged-branch https://github.com/theofficialgman/neofetch.git --depth=1
+cd neofetch && sudo make install || error "Make install failed"
+rm -rf /tmp/neofetch

--- a/apps/Neofetch/packages
+++ b/apps/Neofetch/packages
@@ -1,1 +1,0 @@
-neofetch

--- a/apps/Neofetch/uninstall
+++ b/apps/Neofetch/uninstall
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+purge_packages || exit 1
+
+sudo rm -rf /usr/bin/neofetch /usr/man1/neofetch.1*


### PR DESCRIPTION
adds generic (ARM) gpu support and ARM cpu offiicial name support

before and after pictures:
Before:
![InkedScreenshot_from_2021-10-08_12-31-31](https://user-images.githubusercontent.com/28281419/136889667-ac480602-00c8-4b88-9a2e-ac460352ada2.jpg)
After:
![InkedScreenshot_from_2021-10-08_14-24-32](https://user-images.githubusercontent.com/28281419/136889683-1fa0e1fd-08cd-4faa-9615-f10b3a8b3550.jpg)

On a pi4, gpu info for example will show `V3D 4.2` if using the mesa drivers, and `llvmpipe` if using software rendering. Which is helpful debugging information