### PR TITLE
Box86 update

### DIFF
--- a/api
+++ b/api
@@ -2727,6 +2727,60 @@ fi
 #Make dual-pane yad windows work correctly on wayland
 export GDK_BACKEND=x11
 
+# add upstream and original lsb-release info for all scripts to use
+
+# _os_original_* variables are only set for downstream releases (eg: Pop!_OS, Linux Mint, and KDE Neon)
+# this allows for scripts to simply check for the existance of _os_original_* variables and operate differently if found
+# note: Pop!_OS, Linux Mint, and KDE Neon are NOT official Ubuntu flavors (like Kubuntu, Ubuntu MATE, Ubuntu Kylin, Ubuntu Budgie, Lubuntu, Ubuntu Studio, Ubuntu Unity, and Xubuntu)
+# official Ubuntu flavors use ONLY the official Ubuntu repositories and are directly supported by Ubuntu. These other releases are simply "based" on Ubuntu, much like Raspbian and PiOS are "based" on Debian.
+
+# first check if lsb_release has an upstream option -u
+# if not, check if there is an upstream-release file
+# if not, check if there is a lsb-release.diverted file
+# if not, assume that this is not a ubuntu derivative
+if lsb_release -a -u &>/dev/null; then
+  # This is a Ubuntu Derivative, checking the upstream-release version info
+  __os_id="$(lsb_release -s -i -u)"
+  __os_desc="$(lsb_release -s -d -u)"
+  __os_release="$(lsb_release -s -r -u)"
+  __os_codename="$(lsb_release -s -c -u)"
+  __os_original_id="$(lsb_release -s -i)"
+  __os_original_desc="$(lsb_release -s -d)"
+  __os_original_release="$(lsb_release -s -r)"
+  __os_original_codename="$(lsb_release -s -c)"
+elif [ -f /etc/upstream-release/lsb-release ]; then
+  # ubuntu 22.04+ Linux Mint no longer includes the lsb_release -u option
+  # add a parser for the /etc/upstream-release/lsb-release file
+  source /etc/upstream-release/lsb-release
+  __os_id="$DISTRIB_ID"
+  __os_desc="$DISTRIB_DESCRIPTION"
+  __os_release="$DISTRIB_RELEASE"
+  __os_codename="$DISTRIB_CODENAME"
+  __os_original_id="$(lsb_release -s -i)"
+  __os_original_desc="$(lsb_release -s -d)"
+  __os_original_release="$(lsb_release -s -r)"
+  __os_original_codename="$(lsb_release -s -c)"
+  unset DISTRIB_ID DISTRIB_DESCRIPTION DISTRIB_RELEASE DISTRIB_CODENAME
+elif [ -f /etc/lsb-release.diverted ]; then
+  # ubuntu 22.04+ Pop!_OS no longer includes the /etc/upstream-release/lsb-release or the lsb_release -u option
+  # add a parser for the new /etc/lsb-release.diverted file
+  source /etc/lsb-release.diverted
+  __os_id="$DISTRIB_ID"
+  __os_desc="$DISTRIB_DESCRIPTION"
+  __os_release="$DISTRIB_RELEASE"
+  __os_codename="$DISTRIB_CODENAME"
+  __os_original_id="$(lsb_release -s -i)"
+  __os_original_desc="$(lsb_release -s -d)"
+  __os_original_release="$(lsb_release -s -r)"
+  __os_original_codename="$(lsb_release -s -c)"
+  unset DISTRIB_ID DISTRIB_DESCRIPTION DISTRIB_RELEASE DISTRIB_CODENAME
+else
+  __os_id="$(lsb_release -s -i)"
+  __os_desc="$(lsb_release -s -d)"
+  __os_release="$(lsb_release -s -r)"
+  __os_codename="$(lsb_release -s -c)"
+fi
+
 #if this script is being run standalone, run the specified function
 if [[ "$0" == */api ]];then
   DIRECTORY="$(readlink -f "$(dirname "$0")")"

--- a/apps/Box86/install-32
+++ b/apps/Box86/install-32
@@ -1,21 +1,33 @@
 #!/bin/bash
+
 if dpkg -l box86 &>/dev/null ;then
   sudo apt purge -y box86
 fi
 
-sudo rm -f /etc/apt/sources.list.d/box86.list
-echo "Adding box86 repo..."
-sudo mkdir -p /etc/apt/sources.list.d
-sudo wget https://itai-nelken.github.io/weekly-box86-debs/debian/box86.list -O /etc/apt/sources.list.d/box86.list || error "Failed to download /etc/apt/sources.list.d/box86.list"
-echo "Adding key..."
-wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo apt-key add - || error "Failed to add key to box86 repo!"
-echo "Installing box86..."
-sudo dpkg --remove box86-no-binfmt-restart 2>/dev/null
-install_packages box86 || exit 1
+sudo wget https://ryanfortner.github.io/box86-debs/box86.list -O /etc/apt/sources.list.d/box86.list
+if [ $? != 0 ];then
+  sudo rm -f /etc/apt/sources.list.d/box86.list
+  error "Failed to add box86.list file!"
+fi
 
-if ! sudo systemctl restart systemd-binfmt ;then
-  echo -e "\nWarning: systemd-binfmt failed to restart. Getting debug info..."
-  echo "Running command: 'systemctl status systemd-binfmt.service'"
-  systemctl status systemd-binfmt.service
-  echo "Still exiting with success, but you will have to manually run all x86 applications with box86 as binfmt isn't there to do it for you."
+sudo rm -f /usr/share/keyrings/box86-debs-archive-keyring.gpg
+curl -fsSL https://ryanfortner.github.io/box86-debs/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/box86-debs-archive-keyring.gpg
+
+if [ $? != 0 ];then
+  sudo rm -f /etc/apt/sources.list.d/box86.list
+  error "Failed to add KEY.gpg to APT keyring!"
+fi
+
+# obtain SOC_ID
+get_model
+if [[ "$SOC_ID" == "tegra-x1" ]] || [[ "$SOC_ID" == "tegra-x2" ]]; then
+  install_packages box86-tegrax1 || exit 1
+elif [[ "$SOC_ID" == "rk3399" ]]; then
+  install_packages box86-rk3399 || exit 1
+elif [[ "$SOC_ID" == "bcm2711" ]]; then
+  install_packages box86 || exit 1
+else
+  warning "There is no box86 pre-build for your device $SOC_ID $model"
+  warning "Installing the RPI4 tuned box86 build as a fallback (no crypto extensions enabled)"
+  install_packages box86 || exit 1
 fi

--- a/apps/Box86/install-64
+++ b/apps/Box86/install-64
@@ -33,27 +33,27 @@ if package_installed mesa-va-drivers ; then
   mesa_va_drivers="mesa-va-drivers:armhf"
 fi
 
-if [[ "$(get_codename)" == "bionic" ]] || [[ "$(get_codename)" == "focal" ]] || [[ "$(get_codename)" == "bullseye" ]]; then
-  install_packages libc6:armhf libstdc++6:armhf \
-    libx11-6:armhf \
-    libgtk-3-0:armhf \
-    libgtk2.0-0:armhf libgdk-pixbuf2.0-0:armhf \
-    libpng16-16:armhf libjpeg62:armhf \
-    libopenal1:armhf osspd:armhf libopusfile0:armhf libvorbisfile3:armhf \
-    libcurl4:armhf \
-    libudev1:armhf \
-    libsdl2-2.0-0:armhf libsdl2-mixer-2.0-0:armhf libsdl2-image-2.0-0:armhf libsdl2-net-2.0-0:armhf libsdl2-ttf-2.0-0:armhf \
-    libsdl1.2debian:armhf libsdl-mixer1.2:armhf libsdl-image1.2:armhf libsdl-net1.2:armhf libsdl-sound1.2:armhf libsdl-ttf2.0-0:armhf libsmpeg0:armhf \
-    libcal3d12v5:armhf \
-    libssl1.1:armhf '|' libssl3:armhf libssh-gcrypt-4:armhf \
-    libcups2:armhf \
-    libgssapi-krb5-2:armhf libkrb5-3:armhf \
-    $rpi_arm_userspace $mesa_va_drivers libegl1-mesa:armhf libgl1-mesa-glx:armhf libgles2-mesa:armhf 
-elif [[ "$(get_codename)" == "buster" ]]; then
-  error "User error: Box86 cannot be installed on Raspberry Pi OS Buster 64-bit due to lack of official support. Consider upgrading your system to Raspberry Pi OS Bullseye or use the 32-bit version to install Box86."
-else
-  error "This script can't run on your OS! It HAS to be Raspbian/Debian Bullseye or Ubuntu 20.04"
+if [[ ! -z "$__os_original_id" ]]; then
+  error "User error: Box86 cannot be installed on $__os_original_desc. Please use any official Ubuntu Flavor, Debian, or PiOS/Raspbian Bullseye."
+elif [[ "$__os_codename" == "buster" ]]; then
+  error "User error: Box86 cannot be installed on $__os_desc. Please use any official Ubuntu Flavor, Debian, or PiOS/Raspbian Bullseye."
 fi
+
+install_packages libc6:armhf libstdc++6:armhf \
+  libx11-6:armhf \
+  libgtk-3-0:armhf \
+  libgtk2.0-0:armhf libgdk-pixbuf2.0-0:armhf \
+  libpng16-16:armhf libjpeg62:armhf \
+  libopenal1:armhf osspd:armhf libopusfile0:armhf libvorbisfile3:armhf \
+  libcurl4:armhf \
+  libudev1:armhf \
+  libsdl2-2.0-0:armhf libsdl2-mixer-2.0-0:armhf libsdl2-image-2.0-0:armhf libsdl2-net-2.0-0:armhf libsdl2-ttf-2.0-0:armhf \
+  libsdl1.2debian:armhf libsdl-mixer1.2:armhf libsdl-image1.2:armhf libsdl-net1.2:armhf libsdl-sound1.2:armhf libsdl-ttf2.0-0:armhf libsmpeg0:armhf \
+  libcal3d12v5:armhf \
+  libssl1.1:armhf '|' libssl3:armhf libssh-gcrypt-4:armhf \
+  libcups2:armhf \
+  libgssapi-krb5-2:armhf libkrb5-3:armhf \
+  $rpi_arm_userspace $mesa_va_drivers libegl1-mesa:armhf libgl1-mesa-glx:armhf libgles2-mesa:armhf
 
 sudo wget https://ryanfortner.github.io/box86-debs/box86.list -O /etc/apt/sources.list.d/box86.list
 if [ $? != 0 ];then

--- a/apps/Box86/install-64
+++ b/apps/Box86/install-64
@@ -4,7 +4,6 @@ function check-armhf() {
 	ARMHF="$(dpkg --print-foreign-architectures | grep "armhf")"
 }
 
-
 #add armhf architecture (multiarch)
 check-armhf
 if [[ "$ARMHF" == *"armhf"* ]]; then
@@ -22,28 +21,64 @@ if dpkg -l box86 &>/dev/null ;then
 fi
 
 #install box86 dependencies
-if [[ "$(get_codename)" == "focal" ]]; then
-  install_packages libraspberrypi0:armhf libssh-gcrypt-4:armhf libgssapi-krb5-2:armhf libkrb5-3:armhf libssl1.1:armhf libcups2:armhf libsdl1.2debian:armhf libopusfile0:armhf libc6:armhf libx11-6:armhf libgdk-pixbuf2.0-0:armhf libgtk2.0-0:armhf libstdc++6:armhf libsdl2-2.0-0:armhf mesa-va-drivers:armhf libsdl1.2-dev:armhf libsdl-mixer1.2:armhf libpng16-16:armhf libcal3d12v5:armhf libsdl2-net-2.0-0:armhf libopenal1:armhf libsdl2-image-2.0-0:armhf libvorbis-dev:armhf libcurl4:armhf osspd:armhf pulseaudio libjpeg62:armhf libudev1:armhf libgl1-mesa-dev:armhf libsnappy1v5:armhf libx11-dev:armhf libsmpeg0:armhf libboost-filesystem1.67.0:armhf libboost-program-options1.67.0:armhf libavcodec58:armhf libavformat58:armhf libswscale5:armhf libmyguiengine3debian1v5:armhf libboost-iostreams1.67.0:armhf libsdl2-mixer-2.0-0:armhf || exit 1
-elif [[ "$(get_codename)" == "bullseye" ]]; then
-  install_packages libraspberrypi0:armhf libssh-gcrypt-4:armhf libgssapi-krb5-2:armhf libkrb5-3:armhf libssl1.1:armhf '|' libssl3:armhf libcups2:armhf libsdl1.2debian:armhf libopusfile0:armhf libc6:armhf libx11-6:armhf libgdk-pixbuf2.0-0:armhf libgtk2.0-0:armhf libstdc++6:armhf libsdl2-2.0-0:armhf mesa-va-drivers:armhf libsdl1.2-dev:armhf libsdl-mixer1.2:armhf libpng16-16:armhf libcal3d12v5:armhf libsdl2-net-2.0-0:armhf libopenal1:armhf libsdl2-image-2.0-0:armhf libvorbis-dev:armhf libcurl4:armhf osspd:armhf pulseaudio libjpeg62:armhf libudev1:armhf libgl1-mesa-dev:armhf libsnappy1v5:armhf libx11-dev:armhf libsmpeg0:armhf libboost-filesystem1.74.0:armhf libboost-program-options1.74.0:armhf libavcodec58:armhf libavformat58:armhf libswscale5:armhf libmyguiengine3debian1v5:armhf libboost-iostreams1.74.0:armhf libsdl2-mixer-2.0-0:armhf || exit 1
+unset rpi_arm_userspace
+# only install the libraspberrypi0 arm32 package if the user already has the libraspberrypi0 arm64 package installed
+if package_installed libraspberrypi0 ; then
+  rpi_arm_userspace="libraspberrypi0:armhf"
+fi
+
+unset mesa_va_drivers
+# only install the mesa-va-drivers arm32 package if the user already has the mesa-va-drivers arm64 package installed
+if package_installed mesa-va-drivers ; then
+  mesa_va_drivers="mesa-va-drivers:armhf"
+fi
+
+if [[ "$(get_codename)" == "bionic" ]] || [[ "$(get_codename)" == "focal" ]] || [[ "$(get_codename)" == "bullseye" ]]; then
+  install_packages libc6:armhf libstdc++6:armhf \
+    libx11-6:armhf \
+    libgtk-3-0:armhf \
+    libgtk2.0-0:armhf libgdk-pixbuf2.0-0:armhf \
+    libpng16-16:armhf libjpeg62:armhf \
+    libopenal1:armhf osspd:armhf libopusfile0:armhf libvorbisfile3:armhf \
+    libcurl4:armhf \
+    libudev1:armhf \
+    libsdl2-2.0-0:armhf libsdl2-mixer-2.0-0:armhf libsdl2-image-2.0-0:armhf libsdl2-net-2.0-0:armhf libsdl2-ttf-2.0-0:armhf \
+    libsdl1.2debian:armhf libsdl-mixer1.2:armhf libsdl-image1.2:armhf libsdl-net1.2:armhf libsdl-sound1.2:armhf libsdl-ttf2.0-0:armhf libsmpeg0:armhf \
+    libcal3d12v5:armhf \
+    libssl1.1:armhf '|' libssl3:armhf libssh-gcrypt-4:armhf \
+    libcups2:armhf \
+    libgssapi-krb5-2:armhf libkrb5-3:armhf \
+    $rpi_arm_userspace $mesa_va_drivers libegl1-mesa:armhf libgl1-mesa-glx:armhf libgles2-mesa:armhf 
 elif [[ "$(get_codename)" == "buster" ]]; then
   error "User error: Box86 cannot be installed on Raspberry Pi OS Buster 64-bit due to lack of official support. Consider upgrading your system to Raspberry Pi OS Bullseye or use the 32-bit version to install Box86."
 else
   error "This script can't run on your OS! It HAS to be Raspbian/Debian Bullseye or Ubuntu 20.04"
 fi
 
-sudo rm /etc/apt/sources.list.d/box86.list &>/dev/null
-echo "Adding box86 repo..."
-wget https://itai-nelken.github.io/weekly-box86-debs/debian/box86.list -qO- | sed -r 's/deb /deb [arch=armhf] /' | sudo tee /etc/apt/sources.list.d/box86.list >/dev/null|| error "Failed to download /etc/apt/sources.list.d/box86.list"
-echo "Adding key..."
-wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo apt-key add - || error "Failed to add key to box86 repo!"
-echo "Installing box86..."
-sudo dpkg --remove box86-no-binfmt-restart 2>/dev/null
-install_packages box86:armhf || exit 1
+sudo wget https://ryanfortner.github.io/box86-debs/box86.list -O /etc/apt/sources.list.d/box86.list
+if [ $? != 0 ];then
+  sudo rm -f /etc/apt/sources.list.d/box86.list
+  error "Failed to add box86.list file!"
+fi
 
-if ! sudo systemctl restart systemd-binfmt ;then
-  echo -e "\nWarning: systemd-binfmt failed to restart. Getting debug info..."
-  echo "Running command: 'systemctl status systemd-binfmt.service'"
-  systemctl status systemd-binfmt.service
-  echo "Still exiting with success, but you will have to manually run all x86 applications with box86 as binfmt isn't there to do it for you."
+sudo rm -f /usr/share/keyrings/box86-debs-archive-keyring.gpg
+curl -fsSL https://ryanfortner.github.io/box86-debs/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/box86-debs-archive-keyring.gpg
+
+if [ $? != 0 ];then
+  sudo rm -f /etc/apt/sources.list.d/box86.list
+  error "Failed to add KEY.gpg to APT keyring!"
+fi
+
+# obtain SOC_ID
+get_model
+if [[ "$SOC_ID" == "tegra-x1" ]] || [[ "$SOC_ID" == "tegra-x2" ]]; then
+  install_packages box86-tegrax1:armhf || exit 1
+elif [[ "$SOC_ID" == "rk3399" ]]; then
+  install_packages box86-rk3399:armhf || exit 1
+elif [[ "$SOC_ID" == "bcm2711" ]]; then
+  install_packages box86:armhf || exit 1
+else
+  warning "There is no box86 pre-build for your device $SOC_ID $model"
+  warning "Installing the RPI4 tuned box86 build as a fallback (no crypto extensions enabled)"
+  install_packages box86:armhf || exit 1
 fi

--- a/apps/Box86/install-64
+++ b/apps/Box86/install-64
@@ -47,23 +47,3 @@ if ! sudo systemctl restart systemd-binfmt ;then
   systemctl status systemd-binfmt.service
   echo "Still exiting with success, but you will have to manually run all x86 applications with box86 as binfmt isn't there to do it for you."
 fi
-
-# adding some debug output to the end of the script
-echo "dpkg --print-foreign-architectures:"
-dpkg --print-foreign-architectures
-echo "zcat /proc/config.gz | grep CONFIG_COMPAT="
-zcat /proc/config.gz | grep CONFIG_COMPAT=
-echo "dpkg -l libc6:armhf"
-dpkg -l libc6:armhf
-echo "/lib/arm-linux-gnueabihf/ld-*.so"
-/lib/arm-linux-gnueabihf/ld-*.so
-echo "apt list box86 -a"
-apt list box86 -a
-echo "apt list box86-no-binfmt-restart -a"
-apt list box86-no-binfmt-restart -a
-echo "apt-cache show pi-apps-5f3374a7"
-apt-cache show pi-apps-5f3374a7
-echo "file /usr/local/bin/box86"
-file /usr/local/bin/box86
-echo "/usr/local/bin/box86 --version"
-/usr/local/bin/box86 --version

--- a/apps/Box86/uninstall
+++ b/apps/Box86/uninstall
@@ -9,23 +9,11 @@ function check-armhf() {
 
 purge_packages || exit 1
 
-echo "removing box86 repo..."
 sudo rm -f /etc/apt/sources.list.d/box86.list || error "Failed to remove repo!"
-echo "removing box86 repo key..."
-sudo apt-key remove "5DBC E818 72C0 609D 3C47  61AA EB3C E9A3 37EC DFA4" || error "Failed to remove key!"
-#to set $arch variable
-source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"
+
+sudo rm -f /usr/share/keyrings/box86-debs-archive-keyring.gpg || error "Failed to remove GPG key!"
+
 if [ "$arch" == 64 ]; then
-  
-  sudo dpkg --remove-architecture armhf || warning "armhf architecture should be removed by now, but it isn't!"
-  check-armhf
-  if [[ "$ARMHF" == *"armhf"* ]]; then
-    warning "You probably have some other programs using it, remove it by running 'sudo dpkg --remove-architecture armhf'."
-  fi
-    
-elif [ "$arch" == 32 ]; then
-  #32-bit
-  true #do nothing
-else
-  error "Can't detect OS architecture! something is very wrong!"
+  # remove armhf architecture if no packages from it are currently installed
+  apt list --installed | awk '$3 == "armhf" { print }' | grep -q installed || sudo dpkg --remove-architecture armhf
 fi


### PR DESCRIPTION
depends on merge of this first: https://github.com/ryanfortner/box86-debs/pull/4

reduces complexity of the install scripts, removes libraries that are not possible to be used by box86 and should never have been a part of this script in the first place (boost, ffmpeg, libsnappy, etc).

categorizes packages by type (sound, graphics, sdl1, sdl2, GPU libraries, SSL, etc) and only add ones that are supported by box86 https://github.com/ptitSeb/box86/blob/master/src/library_list.h