### PR TITLE
DDNet: update to 16.8

### DIFF
--- a/apps/DDNet/install
+++ b/apps/DDNet/install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=16.7.1
+version=16.8
 
 if ! package_is_new_enough rustc 1.60.0 ;then
   # Add repository source to apt sources.list


### PR DESCRIPTION
DDNet was causing the entire github runner to exit during compilation (like the entire runner gets killed: https://github.com/Botspot/pi-apps/actions/runs/4421566554/jobs/7752504633#step:5:2969).

Creating this PR for testing purposes on our other runner distros. We are already aware that it will fail on armhf in QEMU but this is a new issue.

Currently testing here: https://github.com/Botspot/pi-apps/actions/runs/4430123730