### PR TITLE
flatpak: add theofficialgman flatpak ppa (and switch other apps to use new api functions)

### DIFF
--- a/.github/workflows/test_build_commands.sh
+++ b/.github/workflows/test_build_commands.sh
@@ -239,19 +239,6 @@ status "Testing app(s): $imported_apps"
 mkdir -p  $HOME/.local/share/applications $HOME/.local/bin
 sudo mkdir -p /usr/local/bin /usr/local/share/applications
 
-# upgrade cmake to 3.20+ from theofficialgman ppa to fix QEMU only issue https://gitlab.kitware.com/cmake/cmake/-/issues/20568
-
-echo "Adding cmake PPA repository..."
-echo "deb [arch=$(dpkg --print-architecture)] https://ppa.launchpadcontent.net/theofficialgman/cmake-bionic/ubuntu bionic main " | sudo tee /etc/apt/sources.list.d/theofficialgman-ubuntu-cmake-bionic-bionic.list || error "Failed to add repository to sources.list!"
-
-# Add cmake ppa keyring
-echo "Signing cmake PPA repository..."
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0ACACB5D1E74E484
-if [ $? != 0 ];then
-  sudo rm -f /etc/apt/sources.list.d/theofficialgman-ubuntu-cmake-bionic-bionic.list
-  error "Failed to sign the cmake PPA!"
-fi
-
 # clean out any app status files
 rm -rf ./data/status
 
@@ -262,6 +249,9 @@ source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"
 #Run runonce entries
 "${DIRECTORY}/etc/runonce-entries"
 set +a #stop exporting functions
+
+# upgrade cmake to 3.20+ from theofficialgman ppa to fix QEMU only issue https://gitlab.kitware.com/cmake/cmake/-/issues/20568
+debian_ppa_installer "theofficialgman/cmake-bionic" "bionic" "0ACACB5D1E74E484" || exit 1
 
 IFS=$'\n'
 for app in $imported_apps ;do

--- a/.github/workflows/update_apps.yml
+++ b/.github/workflows/update_apps.yml
@@ -129,18 +129,16 @@ jobs:
             sudo apt update
             sudo apt install -y yad curl wget aria2 lsb-release software-properties-common apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils rsync
 
+            # runonce-entries is run in the build tester, runonce requires that all api functions be available to subprocess (like is done in the gui script)
+            #for the will_reinstall() and list_intersect() functions
+            set -a #make all functions in the api available to subprocesses
+            source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"
+            #Run runonce entries
+            "${DIRECTORY}/etc/runonce-entries"
+            set +a #stop exporting functions
+
             # upgrade cmake to 3.20+ from theofficialgman ppa to fix QEMU only issue https://gitlab.kitware.com/cmake/cmake/-/issues/20568
-
-            echo "Adding cmake PPA repository..."
-            echo "deb [arch=$(dpkg --print-architecture)] https://ppa.launchpadcontent.net/theofficialgman/cmake-bionic/ubuntu bionic main " | sudo tee /etc/apt/sources.list.d/theofficialgman-ubuntu-cmake-bionic-bionic.list || error "Failed to add repository to sources.list!"
-
-            # Add cmake ppa keyring
-            echo "Signing cmake PPA repository..."
-            sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0ACACB5D1E74E484
-            if [ $? != 0 ];then
-              sudo rm -f /etc/apt/sources.list.d/theofficialgman-ubuntu-cmake-bionic-bionic.list
-              error "Failed to sign the cmake PPA!"
-            fi
+            debian_ppa_installer "theofficialgman/cmake-bionic" "bionic" "0ACACB5D1E74E484" || exit 1
 
             # store apps changed from last commit to working directory in varaible
             mapfile -t changed_apps < <(git diff --name-only | grep ^apps/ | awk -F '/' '{print $2}' | sort -u)
@@ -208,18 +206,16 @@ jobs:
             sudo apt update
             sudo apt install -y yad curl wget aria2 lsb-release software-properties-common apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils rsync
 
+            # runonce-entries is run in the build tester, runonce requires that all api functions be available to subprocess (like is done in the gui script)
+            #for the will_reinstall() and list_intersect() functions
+            set -a #make all functions in the api available to subprocesses
+            source "${DIRECTORY}/api" || error "failed to source ${DIRECTORY}/api"
+            #Run runonce entries
+            "${DIRECTORY}/etc/runonce-entries"
+            set +a #stop exporting functions
+
             # upgrade cmake to 3.20+ from theofficialgman ppa to fix QEMU only issue https://gitlab.kitware.com/cmake/cmake/-/issues/20568
-
-            echo "Adding cmake PPA repository..."
-            echo "deb [arch=$(dpkg --print-architecture)] https://ppa.launchpadcontent.net/theofficialgman/cmake-bionic/ubuntu bionic main " | sudo tee /etc/apt/sources.list.d/theofficialgman-ubuntu-cmake-bionic-bionic.list || error "Failed to add repository to sources.list!"
-
-            # Add cmake ppa keyring
-            echo "Signing cmake PPA repository..."
-            sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0ACACB5D1E74E484
-            if [ $? != 0 ];then
-              sudo rm -f /etc/apt/sources.list.d/theofficialgman-ubuntu-cmake-bionic-bionic.list
-              error "Failed to sign the cmake PPA!"
-            fi
+            debian_ppa_installer "theofficialgman/cmake-bionic" "bionic" "0ACACB5D1E74E484" || exit 1
 
             # store apps changed from last commit to working directory in varaible
             mapfile -t changed_apps < <(git diff --name-only | grep ^apps/ | awk -F '/' '{print $2}' | sort -u)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -334,6 +334,30 @@ This is a special folder (`/tmp/pi-apps-local-packages`) used by the `install_pa
   - This is useful for the `createapp` script to automatically find a suitable icon for package-apps you're trying to add.
   - This uses `dpkg-query` to list all files each package installed. The list is filteres to only show `.png` files in `/icons/` or `/pixmaps/` folders.
   - The list is sorted by filesize to find the picture with the most pixels.
+- `ubuntu_ppa_installer` - Given a ppa name, this function will automatically add the apt repo and key for the current ubuntu dist to the users apt sources.list.d directory.
+  - Example usage:
+    ```bash
+    ubuntu_ppa_installer "ubuntu-mozilla-security/rust-next" || exit 1
+    ```
+  - Removing the repo should be performed as part of an app uninstall script by using the existing pi-apps function `remove_repofile_if_unused`. Repo .list filenames are standardized so the following convention should be used for removal.
+  - Example removal:
+    ```bash
+    ppa_name="ubuntu-mozilla-security/rust-next"
+    ppa_dist="$__os_codename"
+    remove_repofile_if_unused /etc/apt/sources.list.d/${ppa_name%/*}-ubuntu-${ppa_name#*/}-${ppa_dist}.list
+    ```
+- `debian_ppa_installer` - Given a ppa name, dist, and key this function will automatically add the apt repo and key for the specified ubuntu dist to the users apt sources.list.d directory.
+  - Example usage:
+    ```bash
+    debian_ppa_installer "ubuntu-mozilla-security/rust-next" "bionic" "AF316E81A155146718A6FBD7A6DCF7707EBC211F" || exit 1
+    ```
+  - Removing the repo should be performed as part of an app uninstall script by using the existing pi-apps function `remove_repofile_if_unused`. Repo .list filenames are standardized so the following convention should be used for removal.
+  - Example removal:
+    ```bash
+    ppa_name="ubuntu-mozilla-security/rust-next"
+    ppa_dist="focal"
+    remove_repofile_if_unused /etc/apt/sources.list.d/${ppa_name%/*}-ubuntu-${ppa_name#*/}-${ppa_dist}.list
+    ```
 
 End of apt functions. Flatpak functions below.
 

--- a/api
+++ b/api
@@ -688,6 +688,24 @@ flatpak_install() { #install an app using flatpak
     error "flatpak_install(): Could not install $1 because flatpak is not installed!"
   fi
   
+  case "$__os_codename" in
+  buster)
+    debian_ppa_installer "theofficialgman/flatpak-no-bwrap" "bionic" "0ACACB5D1E74E484"
+    apt_lock_wait
+    sudo apt-get --only-upgrade install flatpak -y
+    ;;
+  bullseye)
+    debian_ppa_installer "theofficialgman/flatpak-no-bwrap" "focal" "0ACACB5D1E74E484"
+    apt_lock_wait
+    sudo apt-get --only-upgrade install flatpak -y
+    ;;
+  bionic|focal|jammy)
+    ubuntu_ppa_installer "theofficialgman/flatpak-no-bwrap"
+    apt_lock_wait
+    sudo apt-get --only-upgrade install flatpak -y
+    ;;
+  esac
+  
   status -n "Flatpak: Adding flathub remote... "
   #Add the flathub remote, first as root, if that fails then try installing as user, while removing unwanted output
   ( sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo || flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo || error "Flatpak failed to add flathub remote!"  ) | grep --line-buffered -v "Note that the directories 

--- a/api
+++ b/api
@@ -638,6 +638,45 @@ get_icon_from_package() { #given a package-name, find all png files that it inst
   done
   dpkg-query -L "$@" $extra_packages 2>/dev/null | grep '\.png$\|\.svg$' | grep '/icons/\|/pixmaps/' | xargs wc -c | grep -v ' total' | sort -nr | head -n1 | sed 's/  / /g' | sed 's/^ //g' | tr ' ' '\n' | tail -n +2
 }
+
+ubuntu_ppa_installer() {
+  local ppa_name="$1"
+  [ -z "$1" ] && error "ubuntu_ppa_installer(): This function is used to add a ppa to a ubuntu based install but a required input argument was missing."
+  local ppa_grep="$ppa_name"
+  [[ "${ppa_name}" != */ ]] && local ppa_grep="${ppa_name}/"
+  local ppa_added=$(grep ^ /etc/apt/sources.list /etc/apt/sources.list.d/* | grep -v list.save | grep -v deb-src | grep deb | grep -v '#' | grep "$ppa_grep" | wc -l)
+  if [[ $ppa_added -eq "1" ]]; then
+    status "Skipping $ppa_name PPA, already added"
+  else
+    status "Adding $ppa_name PPA"
+    sudo add-apt-repository "ppa:$ppa_name" -y
+    apt_lock_wait
+    sudo apt update
+  fi
+}
+
+debian_ppa_installer() {
+  local ppa_name="$1"
+  local ppa_dist="$2"
+  local key="$3"
+  [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] && error "debian_ppa_installer(): This function is used to add a ppa to a debian based install but a required input argument was missing."
+  local ppa_grep="$ppa_name"
+  [[ "${ppa_name}" != */ ]] && local ppa_grep="${ppa_name}/ubuntu ${ppa_dist}"
+  local ppa_added=$(grep ^ /etc/apt/sources.list /etc/apt/sources.list.d/* | grep -v list.save | grep -v deb-src | grep deb | grep -v '#' | grep "$ppa_grep" | wc -l)
+  if [[ $ppa_added -eq "1" ]]; then
+    status "Skipping $ppa_name PPA, already added"
+  else
+    status "Adding $ppa_name PPA"
+    echo "deb https://ppa.launchpadcontent.net/${ppa_name}/ubuntu ${ppa_dist} main" | sudo tee /etc/apt/sources.list.d/${ppa_name%/*}-ubuntu-${ppa_name#*/}-${ppa_dist}.list || error "Failed to add repository to sources.list!"
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "$key"
+    if [ $? != 0 ];then
+      sudo rm -f /etc/apt/sources.list.d/${ppa_name%/*}-ubuntu-${ppa_name#*/}-${ppa_dist}.list
+      error "Failed to sign the $ppa_name PPA!"
+    fi
+    apt_lock_wait
+    sudo apt update
+  fi
+}
 #end of apt functions
 
 #flatpak functions

--- a/api
+++ b/api
@@ -136,7 +136,7 @@ package_latest_version() { #returns the latest available versions of the specifi
   #grep -rx "Package: $package" /var/lib/apt/lists --exclude="lock" --exclude-dir="partial" --after 4 | grep -o 'Version: .*' | awk '{print $2}' | sort -rV | head -n1
 }
 
-package_is_new_enough() { #check if the $1 package has an available version greater than $2
+package_is_new_enough() { #check if the $1 package has an available version greater than or equal to $2
   local package="$1"
   [ -z "$package" ] && error "package_is_new_enough(): no package specified!"
   
@@ -688,23 +688,25 @@ flatpak_install() { #install an app using flatpak
     error "flatpak_install(): Could not install $1 because flatpak is not installed!"
   fi
   
-  case "$__os_codename" in
-  buster)
-    debian_ppa_installer "theofficialgman/flatpak-no-bwrap" "bionic" "0ACACB5D1E74E484"
-    apt_lock_wait
-    sudo apt-get --only-upgrade install flatpak -y
-    ;;
-  bullseye)
-    debian_ppa_installer "theofficialgman/flatpak-no-bwrap" "focal" "0ACACB5D1E74E484"
-    apt_lock_wait
-    sudo apt-get --only-upgrade install flatpak -y
-    ;;
-  bionic|focal|jammy)
-    ubuntu_ppa_installer "theofficialgman/flatpak-no-bwrap"
-    apt_lock_wait
-    sudo apt-get --only-upgrade install flatpak -y
-    ;;
-  esac
+  if ! package_is_new_enough flatpak 1.14.4 ;then
+    case "$__os_codename" in
+    buster)
+      debian_ppa_installer "theofficialgman/flatpak-no-bwrap" "bionic" "0ACACB5D1E74E484"
+      apt_lock_wait
+      sudo apt-get --only-upgrade install flatpak -y
+      ;;
+    bullseye)
+      debian_ppa_installer "theofficialgman/flatpak-no-bwrap" "focal" "0ACACB5D1E74E484"
+      apt_lock_wait
+      sudo apt-get --only-upgrade install flatpak -y
+      ;;
+    bionic|focal|jammy)
+      ubuntu_ppa_installer "theofficialgman/flatpak-no-bwrap"
+      apt_lock_wait
+      sudo apt-get --only-upgrade install flatpak -y
+      ;;
+    esac
+  fi
   
   status -n "Flatpak: Adding flathub remote... "
   #Add the flathub remote, first as root, if that fails then try installing as user, while removing unwanted output

--- a/api
+++ b/api
@@ -639,7 +639,7 @@ get_icon_from_package() { #given a package-name, find all png files that it inst
   dpkg-query -L "$@" $extra_packages 2>/dev/null | grep '\.png$\|\.svg$' | grep '/icons/\|/pixmaps/' | xargs wc -c | grep -v ' total' | sort -nr | head -n1 | sed 's/  / /g' | sed 's/^ //g' | tr ' ' '\n' | tail -n +2
 }
 
-ubuntu_ppa_installer() {
+ubuntu_ppa_installer() { #setup a PPA on an Ubuntu distro. Arguments: ppa_name
   local ppa_name="$1"
   [ -z "$1" ] && error "ubuntu_ppa_installer(): This function is used to add a ppa to a ubuntu based install but a required input argument was missing."
   local ppa_grep="$ppa_name"
@@ -649,13 +649,12 @@ ubuntu_ppa_installer() {
     status "Skipping $ppa_name PPA, already added"
   else
     status "Adding $ppa_name PPA"
-    sudo add-apt-repository "ppa:$ppa_name" -y
-    apt_lock_wait
-    sudo apt update
+    sudo add-apt-repository "ppa:$ppa_name" -y || exit 1
+    apt_update || exit 1
   fi
 }
 
-debian_ppa_installer() {
+debian_ppa_installer() { #setup a PPA on a Debian distro. Arguments: ppa_name distribution key
   local ppa_name="$1"
   local ppa_dist="$2"
   local key="$3"
@@ -673,8 +672,7 @@ debian_ppa_installer() {
       sudo rm -f /etc/apt/sources.list.d/${ppa_name%/*}-ubuntu-${ppa_name#*/}-${ppa_dist}.list
       error "Failed to sign the $ppa_name PPA!"
     fi
-    apt_lock_wait
-    sudo apt update
+    apt_update || exit 1
   fi
 }
 #end of apt functions

--- a/api
+++ b/api
@@ -691,17 +691,17 @@ flatpak_install() { #install an app using flatpak
     buster)
       debian_ppa_installer "theofficialgman/flatpak-no-bwrap" "bionic" "0ACACB5D1E74E484"
       apt_lock_wait
-      sudo apt --only-upgrade install flatpak -y
+      sudo apt --only-upgrade install flatpak -y | less_apt
       ;;
     bullseye)
       debian_ppa_installer "theofficialgman/flatpak-no-bwrap" "focal" "0ACACB5D1E74E484"
       apt_lock_wait
-      sudo apt --only-upgrade install flatpak -y
+      sudo apt --only-upgrade install flatpak -y | less_apt
       ;;
     bionic|focal|jammy)
       ubuntu_ppa_installer "theofficialgman/flatpak-no-bwrap"
       apt_lock_wait
-      sudo apt --only-upgrade install flatpak -y
+      sudo apt --only-upgrade install flatpak -y | less_apt
       ;;
     esac
   fi

--- a/api
+++ b/api
@@ -693,17 +693,17 @@ flatpak_install() { #install an app using flatpak
     buster)
       debian_ppa_installer "theofficialgman/flatpak-no-bwrap" "bionic" "0ACACB5D1E74E484"
       apt_lock_wait
-      sudo apt-get --only-upgrade install flatpak -y
+      sudo apt --only-upgrade install flatpak -y
       ;;
     bullseye)
       debian_ppa_installer "theofficialgman/flatpak-no-bwrap" "focal" "0ACACB5D1E74E484"
       apt_lock_wait
-      sudo apt-get --only-upgrade install flatpak -y
+      sudo apt --only-upgrade install flatpak -y
       ;;
     bionic|focal|jammy)
       ubuntu_ppa_installer "theofficialgman/flatpak-no-bwrap"
       apt_lock_wait
-      sudo apt-get --only-upgrade install flatpak -y
+      sudo apt --only-upgrade install flatpak -y
       ;;
     esac
   fi

--- a/apps/DDNet/install
+++ b/apps/DDNet/install
@@ -4,16 +4,9 @@ version=16.8
 
 if ! package_is_new_enough rustc 1.60.0 ;then
   # Add repository source to apt sources.list
-  status "Adding Rust PPA repository..."
-  echo "deb [arch=$(dpkg --print-architecture)] https://ppa.launchpadcontent.net/ubuntu-mozilla-security/rust-next/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/rust-ubuntu.list
-
-  # Add Rust ppa keyring
-  status "Signing Rust PPA repository..."
-  sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AF316E81A155146718A6FBD7A6DCF7707EBC211F
-  if [ $? != 0 ];then
-    sudo rm -f /etc/apt/sources.list.d/rust-ubuntu.list
-    error "Failed to sign the Rust PPA!"
-  fi
+  # remove deprecated repofilename
+  sudo rm -f /etc/apt/sources.list.d/rust-ubuntu.list
+  debian_ppa_installer "ubuntu-mozilla-security/rust-next" "bionic" "AF316E81A155146718A6FBD7A6DCF7707EBC211F" || exit 1
 fi
 
 #Dependencies

--- a/apps/DDNet/uninstall
+++ b/apps/DDNet/uninstall
@@ -2,7 +2,12 @@
 
 purge_packages || exit 1
 
-remove_repofile_if_unused /etc/apt/sources.list.d/rust-ubuntu.list
+# remove deprecated repofilename
+sudo rm -f /etc/apt/sources.list.d/rust-ubuntu.list
+# remove repofile if unused
+ppa_name="ubuntu-mozilla-security/rust-next"
+ppa_dist="bionic"
+remove_repofile_if_unused /etc/apt/sources.list.d/${ppa_name%/*}-ubuntu-${ppa_name#*/}-${ppa_dist}.list
 
 sudo rm -rf /usr/local/share/ddnet \
 /usr/local/bin/DDNet \

--- a/apps/Firefox Rapid Release/install
+++ b/apps/Firefox Rapid Release/install
@@ -2,18 +2,10 @@
 
 # it would unnecessary to run this on bionic, check and skip adding the repo if on ubuntu bionic
 if [[ "$get_codename" != "bionic" ]]; then
+  # remove deprecated repofilename
+  sudo rm -f /etc/apt/sources.list.d/firefox-ubuntu.list
   # Add repository source to apt sources.list
-  echo "Adding firefox PPA repository..."
-  echo "deb [arch=$(dpkg --print-architecture)] https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/firefox-ubuntu.list || error "Failed to add repository to sources.list!"
-
-  # Add firefox ppa keyring
-  echo "Signing firefox PPA repository..."
-  sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0AB215679C571D1C8325275B9BDB3D89CE49EC21
-  if [ $? != 0 ];then
-    sudo rm -f /etc/apt/sources.list.d/firefox-ubuntu.list
-    error "Failed to sign the firefox PPA!"
-  fi
-
+  debian_ppa_installer "mozillateam/ppa" "bionic" "0AB215679C571D1C8325275B9BDB3D89CE49EC21" || exit 1
   # remove /etc/apt/preferences.d/99bionic-updates which was added when bionic default repositories were added
   sudo rm -f /etc/apt/preferences.d/99bionic-updates
 fi

--- a/apps/Firefox Rapid Release/uninstall
+++ b/apps/Firefox Rapid Release/uninstall
@@ -1,4 +1,9 @@
 #!/bin/bash
 purge_packages || exit 1
 sudo rm -f /etc/apt/preferences.d/99bionic-updates
+# remove deprecated repofilename
 sudo rm -f /etc/apt/sources.list.d/firefox-ubuntu.list
+# remove repofile if unused
+ppa_name="mozillateam/ppa"
+ppa_dist="bionic"
+remove_repofile_if_unused /etc/apt/sources.list.d/${ppa_name%/*}-ubuntu-${ppa_name#*/}-${ppa_dist}.list


### PR DESCRIPTION
currently provides `flatpak` 1.14.4 for bionic/focal/jammy. buster uses bionic repo, bullseye uses focal repo.
also provides `xdg-desktop-portal` and `xdg-desktop-portal-gtk` 1.7.X for bionic/buster