### PR TITLE
Switch to adoptium from openjdk

### DIFF
--- a/api
+++ b/api
@@ -693,6 +693,45 @@ debian_ppa_installer() { #setup a PPA on a Debian distro. Arguments: ppa_name di
   fi
 }
 
+adoptium_installer() {
+  status "Adding Adoptium repository:"
+
+  echo "- public key -> keyring"
+  rm -f /tmp/adoptium-public-key /tmp/adoptium-archive-keyring.gpg
+  wget -O /tmp/adoptium-public-key https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public
+  gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --import /tmp/adoptium-public-key
+  rm -f /tmp/adoptium-public-key
+
+  echo " - keyring -> GPG key"
+  gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --export --output /tmp/adoptium-archive-keyring.gpg
+  rm -f /tmp/adoptium-keyring.gpg
+
+  echo " - Moving GPG key to /usr/share/keyrings"
+  sudo mv -f /tmp/adoptium-archive-keyring.gpg /usr/share/keyrings
+
+  echo " - Creating /etc/apt/sources.list.d/adoptium.list"
+  case "$__os_codename" in
+  bionic | focal | jammy | buster | bullseye | bookworm)
+    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb $__os_codename main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
+    ;;
+  *)
+    # use bionic target name explicitly for any other OS as its the oldest LTS target adoptium continues to support
+    # all supported adoptium OSs use the same debs so the target specified does not actually matter
+    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb bionic main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
+    ;;
+  esac
+  apt_update
+  if [ $? != 0 ]; then
+    anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb"
+    if [ $? != 0 ]; then
+      # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
+      # safe to remove
+      sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
+    fi
+    error "Failed to perform apt update after adding Adoptium repository."
+  fi
+}
+
 terminal_manage() { # wrapper for the original terminal_manage function to terminal_mange_multi
   action="$1"
   app="$2" #one app name

--- a/apps/Angry IP scanner/install-64
+++ b/apps/Angry IP scanner/install-64
@@ -1,4 +1,7 @@
 #!/bin/bash
 
 version=3.9.1
-install_packages openjdk-11-jdk rpm fakeroot "https://github.com/angryip/ipscan/releases/download/${version}/ipscan_${version}_all.deb" || exit 1
+adoptium_installer || exit 1
+# install temurin-17-jre first so that when apt looks for "Provides: java11-runtime" to satisfy ipscan dependencies it will be there
+install_packages temurin-17-jre || exit 1
+install_packages rpm fakeroot "https://github.com/angryip/ipscan/releases/download/${version}/ipscan_${version}_all.deb" || exit 1

--- a/apps/Angry IP scanner/uninstall
+++ b/apps/Angry IP scanner/uninstall
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 purge_packages || exit 1
+remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list

--- a/apps/Intellij IDEA/install-32
+++ b/apps/Intellij IDEA/install-32
@@ -2,10 +2,36 @@
 
 version=2022.1.4
 
-# Get dependencies
-install_packages build-essential openjdk-11-jdk || exit 1
+status "Installing Java 17"
+case "$__os_id" in
+# Raspbian is not reported as a derivative of Debian (no /etc/upstream-release/lsb-release file)
+Raspbian | Debian)
+  if printf '%s\n' "10" "$__os_release" | sort -CV; then
+    adoptium_installer || exit 1
+    install_packages temurin-17-jdk || exit 1
+    java_home="$(dpkg -L temurin-17-jdk | grep "/usr/lib/jvm.*$(dpkg --print-architecture)$")"
+  else
+    error "Debian version ($__os_codename) is too old, update to debian Buster or newer"
+  fi
+  ;;
+Kali)
+  adoptium_installer || exit 1
+  install_packages temurin-17-jdk || exit 1
+  java_home="$(dpkg -L temurin-17-jdk | grep "/usr/lib/jvm.*$(dpkg --print-architecture)$")"
+  ;;
+Ubuntu)
+  # ubuntu default repositories now include openjdk-17
+  # install java
+  install_packages openjdk-17-jdk || exit 1
+  java_home="$(dpkg -L openjdk-17-jdk | grep "/usr/lib/jvm.*$(dpkg --print-architecture)$")"
+  ;;
+*)
+  error "$__os_id appears to be an unsupported OS"
+  ;;
+esac
 
-java_home="$(dpkg -L openjdk-11-jdk | grep "/usr/lib/jvm.*$(dpkg --print-architecture)$")"
+# Get dependencies
+install_packages build-essential || exit 1
 
 sudo rm -rf /opt/ideaIC /opt/ideaIC.tar.gz
 sudo mkdir /opt/ideaIC || error "Failed to make idea_ic folder!"

--- a/apps/Intellij IDEA/install-64
+++ b/apps/Intellij IDEA/install-64
@@ -3,124 +3,20 @@
 version=2023.1.4
 
 status "Installing Java 17"
-# first check if lsb_release has an upstream option -u
-# if not, check if there is an upstream-release file
-# if not, check if there is a lsb-release.diverted file
-# if not, assume that this is not a ubuntu derivative
-if lsb_release -a -u &>/dev/null; then
-  # This is a Ubuntu Derivative, checking the upstream-release version info
-  __os_id="$(lsb_release -s -i -u)"
-  __os_desc="$(lsb_release -s -d -u)"
-  __os_release="$(lsb_release -s -r -u)"
-  __os_codename="$(lsb_release -s -c -u)"
-elif [ -f /etc/upstream-release/lsb-release ]; then
-  # ubuntu 22.04+ linux mint no longer includes the lsb_release -u option
-  # add a parser for the /etc/upstream-release/lsb-release file
-  source /etc/upstream-release/lsb-release
-  __os_id="$DISTRIB_ID"
-  __os_desc="$DISTRIB_DESCRIPTION"
-  __os_release="$DISTRIB_RELEASE"
-  __os_codename="$DISTRIB_CODENAME"
-  unset DISTRIB_ID DISTRIB_DESCRIPTION DISTRIB_RELEASE DISTRIB_CODENAME
-elif [ -f /etc/lsb-release.diverted ]; then
-  # ubuntu 22.04+ popOS no longer includes the /etc/upstream-release/lsb-release or the lsb_release -u option
-  # add a parser for the new /etc/lsb-release.diverted file
-  source /etc/lsb-release.diverted
-  __os_id="$DISTRIB_ID"
-  __os_desc="$DISTRIB_DESCRIPTION"
-  __os_release="$DISTRIB_RELEASE"
-  __os_codename="$DISTRIB_CODENAME"
-  unset DISTRIB_ID DISTRIB_DESCRIPTION DISTRIB_RELEASE DISTRIB_CODENAME
-else
-  __os_id="$(lsb_release -s -i)"
-  __os_desc="$(lsb_release -s -d)"
-  __os_release="$(lsb_release -s -r)"
-  __os_codename="$(lsb_release -s -c)"
-fi
 case "$__os_id" in
 # Raspbian is not reported as a derivative of Debian (no /etc/upstream-release/lsb-release file)
 Raspbian | Debian)
-  case "$__os_codename" in
-  bullseye | buster)
-    install_packages lsb-release wget apt-transport-https gnupg || error "Failed to install dependencies"
-    hash -r
-
-    status "Adding Adoptium repository:"
-
-    echo "- public key -> keyring"
-    rm -f /tmp/adoptium-public-key /tmp/adoptium-archive-keyring.gpg
-    wget -O /tmp/adoptium-public-key https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public
-    gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --import /tmp/adoptium-public-key
-    rm -f /tmp/adoptium-public-key
-
-    echo " - keyring -> GPG key"
-    gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --export --output /tmp/adoptium-archive-keyring.gpg
-    rm -f /tmp/adoptium-keyring.gpg
-
-    echo " - Moving GPG key to /usr/share/keyrings"
-    sudo mv -f /tmp/adoptium-archive-keyring.gpg /usr/share/keyrings
-
-    echo " - Creating /etc/apt/sources.list.d/adoptium.list"
-    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb $__os_codename main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
-
-    echo " - Installing temurin-17-jdk"
-    #try to install temurin java versions; if it fails, remove repository to avoid breaking user's system
-    (install_packages temurin-17-jdk)
-    if [ $? != 0 ]; then
-      anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb"
-      if [ $? != 0 ]; then
-        # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-        # safe to remove
-        sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
-      fi
-      error "Failed to install temurin packages. Adoptium repository has been removed."
-    fi
+  if printf '%s\n' "10" "$__os_release" | sort -CV; then
+    adoptium_installer || exit 1
+    install_packages temurin-17-jdk || exit 1
     java_home="$(dpkg -L temurin-17-jdk | grep "/usr/lib/jvm.*$(dpkg --print-architecture)$")"
-    ;;
-  bookworm | sid)
-    warning "You are running Debian $__os_codename which is an unstable repo."
-    install_packages openjdk-17-jdk || exit 1
-    java_home="$(dpkg -L openjdk-17-jdk | grep "/usr/lib/jvm.*$(dpkg --print-architecture)$")"
-    ;;
-  *)
+  else
     error "Debian version ($__os_codename) is too old, update to debian Buster or newer"
-    ;;
-  esac
+  fi
   ;;
 Kali)
-  install_packages wget apt-transport-https gnupg || error "Failed to install dependencies"
-  hash -r
-
-  status "Adding Adoptium repository:"
-
-  echo "- public key -> keyring"
-  rm -f /tmp/adoptium-public-key /tmp/adoptium-archive-keyring.gpg
-  wget -O /tmp/adoptium-public-key https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public
-  gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --import /tmp/adoptium-public-key
-  rm -f /tmp/adoptium-public-key
-
-  echo " - keyring -> GPG key"
-  gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --export --output /tmp/adoptium-archive-keyring.gpg
-  rm -f /tmp/adoptium-keyring.gpg
-
-  echo " - Moving GPG key to /usr/share/keyrings"
-  sudo mv -f /tmp/adoptium-archive-keyring.gpg /usr/share/keyrings
-
-  echo " - Creating /etc/apt/sources.list.d/adoptium.list"
-  echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb buster main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
-
-  echo " - Installing temurin-17-jdk"
-  #try to install temurin java versions; if it fails, remove repository to avoid breaking user's system
-  (install_packages temurin-17-jdk)
-  if [ $? != 0 ]; then
-    anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb"
-    if [ $? != 0 ]; then
-      # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-      # safe to remove
-      sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
-    fi
-    error "Failed to install temurin packages. Adoptium repository has been removed."
-  fi
+  adoptium_installer || exit 1
+  install_packages temurin-17-jdk || exit 1
   java_home="$(dpkg -L temurin-17-jdk | grep "/usr/lib/jvm.*$(dpkg --print-architecture)$")"
   ;;
 Ubuntu)

--- a/apps/Minecraft Java MultiMC5/install
+++ b/apps/Minecraft Java MultiMC5/install
@@ -22,119 +22,32 @@ status "Installing Necessary Dependencies"
 case "$__os_id" in
 # Raspbian is not reported as a derivative of Debian (no /etc/upstream-release/lsb-release file)
 Raspbian | Debian)
-  case "$__os_codename" in
-  bullseye | buster | stretch | jessie)
-    install_packages lsb-release wget apt-transport-https gnupg || error "Failed to install dependencies"
-    hash -r
-
-    status "Adding Adoptium repository:"
-
-    echo "- public key -> keyring"
-    rm -f /tmp/adoptium-public-key /tmp/adoptium-archive-keyring.gpg
-    wget -O /tmp/adoptium-public-key https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public
-    gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --import /tmp/adoptium-public-key
-    rm -f /tmp/adoptium-public-key
-
-    echo " - keyring -> GPG key"
-    gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --export --output /tmp/adoptium-archive-keyring.gpg
-    rm -f /tmp/adoptium-keyring.gpg
-
-    echo " - Moving GPG key to /usr/share/keyrings"
-    sudo mv -f /tmp/adoptium-archive-keyring.gpg /usr/share/keyrings
-
-    echo " - Creating /etc/apt/sources.list.d/adoptium.list"
-    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb $__os_codename main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
-
-    echo " - Installing temurin-8-jre temurin-17-jre"
-    #try to install temurin and adoptopenjdk java versions; if it fails, remove repository to avoid breaking user's system
-    (install_packages temurin-8-jre temurin-17-jre)
-    if [ $? != 0 ]; then
-      anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb"
-      if [ $? != 0 ]; then
-        # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-        # safe to remove
-        sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
-      fi
-      warning "Failed to install temurin packages. Adoptium repository has been removed." && warning "It is up to you to download and install a working java 8 and 17 version." && echo "" && warning "Continuing the MultiMC5 Install without Java 8 and 17"
-    fi
-    ;;
-  bookworm | sid)
-    warning "You are running Debian $__os_codename which is an unstable repo, you may not have Java 8 or 17 installed by this script."
-    java_8=""
-    package_available openjdk-8-jre
-    if [[ $? == "0" ]]; then
-      java_8="openjdk-8-jre"
-    fi
-    java_17=""
-    package_available openjdk-17-jre
-    if [[ $? == "0" ]]; then
-      java_17="openjdk-17-jre"
-    fi
-    if [ ! -z "$java_8" ] || [ ! -z "$java_17" ]; then
-      # either java 8 or 17 is found to be available by package_available, attempt to install them
-      install_packages $java_8 $java_17 || warning "Failed to install install a working java 8 or 17. You will have to install these yourself. Continuing the install without them."
-    fi
-    ;;
-  *)
-    error "Debian version ($__os_codename) is too old, update to debian Jessie or newer"
-    ;;
-  esac
-
-  # install normal dependencies from raspbian/debian repos
-  install_packages build-essential libopenal1 x11-xserver-utils subversion git clang cmake curl zlib1g-dev openjdk-11-jdk qtbase5-dev mesa-utils || error "Failed to install dependencies on $__os_codename"
+  if printf '%s\n' "10" "$__os_release" | sort -CV; then
+    adoptium_installer || exit 1
+    install_packages temurin-8-jre temurin-17-jdk || exit 1
+    java_home="$(dpkg -L temurin-17-jdk | grep "/usr/lib/jvm.*$(dpkg --print-architecture)$")"
+  else
+    error "Debian version ($__os_codename) is too old, update to debian Buster or newer"
+  fi
   ;;
 Kali)
-  install_packages wget apt-transport-https gnupg || error "Failed to install dependencies"
-  hash -r
-
-  status "Adding Adoptium repository:"
-
-  echo "- public key -> keyring"
-  rm -f /tmp/adoptium-public-key /tmp/adoptium-archive-keyring.gpg
-  wget -O /tmp/adoptium-public-key https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public
-  gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --import /tmp/adoptium-public-key
-  rm -f /tmp/adoptium-public-key
-
-  echo " - keyring -> GPG key"
-  gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --export --output /tmp/adoptium-archive-keyring.gpg
-  rm -f /tmp/adoptium-keyring.gpg
-
-  echo " - Moving GPG key to /usr/share/keyrings"
-  sudo mv -f /tmp/adoptium-archive-keyring.gpg /usr/share/keyrings
-
-  echo " - Creating /etc/apt/sources.list.d/adoptium.list"
-  echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb buster main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
-
-  echo " - Installing temurin-8-jre temurin-17-jre"
-  #try to install temurin and adoptopenjdk java versions; if it fails, remove repository to avoid breaking user's system
-  (install_packages temurin-8-jre temurin-17-jre)
-  if [ $? != 0 ]; then
-    anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb"
-    if [ $? != 0 ]; then
-      # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-      # safe to remove
-      sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
-    fi
-    warning "Failed to install temurin packages. Adoptium repository has been removed." && warning "It is up to you to download and install a working java 8 and 17 version." && echo "" && warning "Continuing the MultiMC5 Install without Java 8 and 17"
-  fi
-
-  # remove old java installs to free up space
-  rm -rf ~/MultiMC/install/java
-  # install normal dependencies from raspbian/debian repos
-  install_packages build-essential libopenal1 x11-xserver-utils subversion git clang cmake curl zlib1g-dev openjdk-11-jdk qtbase5-dev mesa-utils || error "Failed to install dependencies on $__os_codename"
+  adoptium_installer || exit 1
+  install_packages temurin-8-jre temurin-17-jdk || exit 1
+  java_home="$(dpkg -L temurin-17-jdk | grep "/usr/lib/jvm.*$(dpkg --print-architecture)$")"
   ;;
 Ubuntu)
-  requiredver="18.04"
-  if ! printf '%s\n' "$requiredver" "$__os_release" | sort -CV; then
-    error_user "$__os_codename appears to be too old to run/compile MultiMC5"
-  fi
-  # install dependencies
-  install_packages build-essential libopenal1 x11-xserver-utils git clang cmake curl zlib1g-dev openjdk-8-jre openjdk-11-jdk openjdk-17-jre qtbase5-dev || error "Failed to install dependencies"
+  # ubuntu default repositories now include openjdk-17
+  # install java
+  install_packages openjdk-8-jre openjdk-17-jdk || exit 1
+  java_home="$(dpkg -L openjdk-17-jdk | grep "/usr/lib/jvm.*$(dpkg --print-architecture)$")"
   ;;
 *)
   error "$__os_id appears to be an unsupported OS"
   ;;
 esac
+
+# install normal dependencies
+install_packages build-essential libopenal1 x11-xserver-utils subversion git clang cmake curl zlib1g-dev qtbase5-dev mesa-utils || error "Failed to install dependencies on $__os_codename"
 
 hash -r
 
@@ -210,8 +123,8 @@ get_system
 rm -rf CMakeCache.txt
 status "Generating the CMake File"
 case "$arch" in
-"64") cmake -DLauncher_EMBED_SECRETS=ON -DJAVA_HOME='/usr/lib/jvm/java-11-openjdk-arm64' -DLauncher_BUILD_PLATFORM="$model" -DLauncher_BUG_TRACKER_URL="https://github.com/Botspot/pi-apps/issues" -DLauncher_DISCORD_URL="https://discord.gg/RXSTvaUvuu" -DCMAKE_INSTALL_PREFIX=../install -DLauncher_META_URL:STRING="https://raw.githubusercontent.com/theofficialgman/meta-multimc/master-clean/index.json" ../src || error "cmake failed to generate" ;;
-"32") cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLauncher_EMBED_SECRETS=ON -DJAVA_HOME='/usr/lib/jvm/java-11-openjdk-armhf' -DLauncher_BUILD_PLATFORM="$model" -DLauncher_BUG_TRACKER_URL="https://github.com/Botspot/pi-apps/issues" -DLauncher_DISCORD_URL="https://discord.gg/RXSTvaUvuu" -DCMAKE_INSTALL_PREFIX=../install -DLauncher_META_URL:STRING="https://raw.githubusercontent.com/theofficialgman/meta-multimc/master-clean-arm32/index.json" ../src || error "cmake failed to generate" ;;
+"64") cmake -DLauncher_EMBED_SECRETS=ON -DJAVA_HOME="$java_home" -DLauncher_BUILD_PLATFORM="$model" -DLauncher_BUG_TRACKER_URL="https://github.com/Botspot/pi-apps/issues" -DLauncher_DISCORD_URL="https://discord.gg/RXSTvaUvuu" -DCMAKE_INSTALL_PREFIX=../install -DLauncher_META_URL:STRING="https://raw.githubusercontent.com/theofficialgman/meta-multimc/master-clean/index.json" ../src || error "cmake failed to generate" ;;
+"32") cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLauncher_EMBED_SECRETS=ON -DJAVA_HOME="$java_home" -DLauncher_BUILD_PLATFORM="$model" -DLauncher_BUG_TRACKER_URL="https://github.com/Botspot/pi-apps/issues" -DLauncher_DISCORD_URL="https://discord.gg/RXSTvaUvuu" -DCMAKE_INSTALL_PREFIX=../install -DLauncher_META_URL:STRING="https://raw.githubusercontent.com/theofficialgman/meta-multimc/master-clean-arm32/index.json" ../src || error "cmake failed to generate" ;;
 *) error "Failed to detect OS CPU architecture! Something is very wrong." ;;
 esac
 

--- a/apps/Minecraft Java Prism Launcher/install-32
+++ b/apps/Minecraft Java Prism Launcher/install-32
@@ -16,104 +16,12 @@ fi
 status "Installing Java 8 and 17"
 case "$__os_id" in
 # Raspbian is not reported as a derivative of Debian (no /etc/upstream-release/lsb-release file)
-Raspbian | Debian)
-  case "$__os_codename" in
-  bullseye | buster)
-    install_packages lsb-release wget apt-transport-https gnupg || error "Failed to install dependencies"
-    hash -r
-
-    status "Adding Adoptium repository:"
-
-    echo "- public key -> keyring"
-    rm -f /tmp/adoptium-public-key /tmp/adoptium-archive-keyring.gpg
-    wget -O /tmp/adoptium-public-key https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public
-    gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --import /tmp/adoptium-public-key
-    rm -f /tmp/adoptium-public-key
-
-    echo " - keyring -> GPG key"
-    gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --export --output /tmp/adoptium-archive-keyring.gpg
-    rm -f /tmp/adoptium-keyring.gpg
-
-    echo " - Moving GPG key to /usr/share/keyrings"
-    sudo mv -f /tmp/adoptium-archive-keyring.gpg /usr/share/keyrings
-
-    echo " - Creating /etc/apt/sources.list.d/adoptium.list"
-    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb $__os_codename main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
-
-    echo " - Installing temurin-8-jre temurin-17-jre"
-    #try to install temurin and adoptopenjdk java versions; if it fails, remove repository to avoid breaking user's system
-    (install_packages temurin-8-jre temurin-17-jre)
-    if [ $? != 0 ]; then
-      anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb"
-      if [ $? != 0 ]; then
-        # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-        # safe to remove
-        sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
-      fi
-      warning "Failed to install temurin packages. Adoptium repository has been removed." && warning "It is up to you to download and install a working java 8 and 17 version." && echo "" && warning "Continuing the install without them."
-    fi
-    ;;
-  bookworm | sid)
-    warning "You are running Debian $__os_codename which is an unstable repo, you may not have Java 8 or 17 installed by this script."
-    java_8=""
-    package_available openjdk-8-jre
-    if [[ $? == "0" ]]; then
-      java_8="openjdk-8-jre"
-    fi
-    java_17=""
-    package_available openjdk-17-jre
-    if [[ $? == "0" ]]; then
-      java_17="openjdk-17-jre"
-    fi
-    if [ ! -z "$java_8" ] || [ ! -z "$java_17" ]; then
-      # either java 8 or 17 is found to be available by package_available, attempt to install them
-      install_packages $java_8 $java_17 || warning "Failed to install install a working java 8 or 17. You will have to install these yourself. Continuing the install without them."
-    fi
-    ;;
-  *)
-    error "Debian version ($__os_codename) is too old, update to debian Buster or newer"
-    ;;
-  esac
-  ;;
-Kali)
-  install_packages wget apt-transport-https gnupg || error "Failed to install dependencies"
-  hash -r
-
-  status "Adding Adoptium repository:"
-
-  echo "- public key -> keyring"
-  rm -f /tmp/adoptium-public-key /tmp/adoptium-archive-keyring.gpg
-  wget -O /tmp/adoptium-public-key https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public
-  gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --import /tmp/adoptium-public-key
-  rm -f /tmp/adoptium-public-key
-
-  echo " - keyring -> GPG key"
-  gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --export --output /tmp/adoptium-archive-keyring.gpg
-  rm -f /tmp/adoptium-keyring.gpg
-
-  echo " - Moving GPG key to /usr/share/keyrings"
-  sudo mv -f /tmp/adoptium-archive-keyring.gpg /usr/share/keyrings
-
-  echo " - Creating /etc/apt/sources.list.d/adoptium.list"
-  echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb buster main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
-
-  echo " - Installing temurin-8-jre temurin-17-jre"
-  #try to install temurin and adoptopenjdk java versions; if it fails, remove repository to avoid breaking user's system
-  (install_packages temurin-8-jre temurin-17-jre)
-  if [ $? != 0 ]; then
-    anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb"
-    if [ $? != 0 ]; then
-      # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-      # safe to remove
-      sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
-    fi
-    warning "Failed to install temurin packages. Adoptium repository has been removed." && warning "It is up to you to download and install a working java 8 and 17 version." && echo "" && warning "Continuing the install without them."
-  fi
+Raspbian | Debian | Kali)
+  adoptium_installer || exit 1
+  install_packages temurin-8-jre temurin-17-jre || exit 1
   ;;
 Ubuntu)
-  # ubuntu default repositories now include openjdk-8 openjdk-11 and openjdk-17
-  # install java
-  install_packages openjdk-8-jre openjdk-17-jre || error "Failed to install java 8 and 17"
+  install_packages openjdk-8-jre openjdk-17-jre || exit 1
   ;;
 *)
   error "$__os_id appears to be an unsupported OS"

--- a/apps/Minecraft Java Prism Launcher/install-64
+++ b/apps/Minecraft Java Prism Launcher/install-64
@@ -16,104 +16,12 @@ fi
 status "Installing Java 8 and 17"
 case "$__os_id" in
 # Raspbian is not reported as a derivative of Debian (no /etc/upstream-release/lsb-release file)
-Raspbian | Debian)
-  case "$__os_codename" in
-  bullseye | buster)
-    install_packages lsb-release wget apt-transport-https gnupg || error "Failed to install dependencies"
-    hash -r
-
-    status "Adding Adoptium repository:"
-
-    echo "- public key -> keyring"
-    rm -f /tmp/adoptium-public-key /tmp/adoptium-archive-keyring.gpg
-    wget -O /tmp/adoptium-public-key https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public
-    gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --import /tmp/adoptium-public-key
-    rm -f /tmp/adoptium-public-key
-
-    echo " - keyring -> GPG key"
-    gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --export --output /tmp/adoptium-archive-keyring.gpg
-    rm -f /tmp/adoptium-keyring.gpg
-
-    echo " - Moving GPG key to /usr/share/keyrings"
-    sudo mv -f /tmp/adoptium-archive-keyring.gpg /usr/share/keyrings
-
-    echo " - Creating /etc/apt/sources.list.d/adoptium.list"
-    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb $__os_codename main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
-
-    echo " - Installing temurin-8-jre temurin-17-jre"
-    #try to install temurin and adoptopenjdk java versions; if it fails, remove repository to avoid breaking user's system
-    (install_packages temurin-8-jre temurin-17-jre)
-    if [ $? != 0 ]; then
-      anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb"
-      if [ $? != 0 ]; then
-        # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-        # safe to remove
-        sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
-      fi
-      warning "Failed to install temurin packages. Adoptium repository has been removed." && warning "It is up to you to download and install a working java 8 and 17 version." && echo "" && warning "Continuing the install without them."
-    fi
-    ;;
-  bookworm | sid)
-    warning "You are running Debian $__os_codename which is an unstable repo, you may not have Java 8 or 17 installed by this script."
-    java_8=""
-    package_available openjdk-8-jre
-    if [[ $? == "0" ]]; then
-      java_8="openjdk-8-jre"
-    fi
-    java_17=""
-    package_available openjdk-17-jre
-    if [[ $? == "0" ]]; then
-      java_17="openjdk-17-jre"
-    fi
-    if [ ! -z "$java_8" ] || [ ! -z "$java_17" ]; then
-      # either java 8 or 17 is found to be available by package_available, attempt to install them
-      install_packages $java_8 $java_17 || warning "Failed to install install a working java 8 or 17. You will have to install these yourself. Continuing the install without them."
-    fi
-    ;;
-  *)
-    error "Debian version ($__os_codename) is too old, update to debian Buster or newer"
-    ;;
-  esac
-  ;;
-Kali)
-  install_packages wget apt-transport-https gnupg || error "Failed to install dependencies"
-  hash -r
-
-  status "Adding Adoptium repository:"
-
-  echo "- public key -> keyring"
-  rm -f /tmp/adoptium-public-key /tmp/adoptium-archive-keyring.gpg
-  wget -O /tmp/adoptium-public-key https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public
-  gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --import /tmp/adoptium-public-key
-  rm -f /tmp/adoptium-public-key
-
-  echo " - keyring -> GPG key"
-  gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --export --output /tmp/adoptium-archive-keyring.gpg
-  rm -f /tmp/adoptium-keyring.gpg
-
-  echo " - Moving GPG key to /usr/share/keyrings"
-  sudo mv -f /tmp/adoptium-archive-keyring.gpg /usr/share/keyrings
-
-  echo " - Creating /etc/apt/sources.list.d/adoptium.list"
-  echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb buster main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
-
-  echo " - Installing temurin-8-jre temurin-17-jre"
-  #try to install temurin and adoptopenjdk java versions; if it fails, remove repository to avoid breaking user's system
-  (install_packages temurin-8-jre temurin-17-jre)
-  if [ $? != 0 ]; then
-    anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb"
-    if [ $? != 0 ]; then
-      # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-      # safe to remove
-      sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
-    fi
-    warning "Failed to install temurin packages. Adoptium repository has been removed." && warning "It is up to you to download and install a working java 8 and 17 version." && echo "" && warning "Continuing the install without them."
-  fi
+Raspbian | Debian | Kali)
+  adoptium_installer || exit 1
+  install_packages temurin-8-jre temurin-17-jre || exit 1
   ;;
 Ubuntu)
-  # ubuntu default repositories now include openjdk-8 openjdk-11 and openjdk-17
-  # install java
-  install_packages openjdk-8-jre openjdk-17-jre || error "Failed to install java 8 and 17"
+  install_packages openjdk-8-jre openjdk-17-jre || exit 1
   ;;
 *)
   error "$__os_id appears to be an unsupported OS"

--- a/apps/Minecraft Java Server/install
+++ b/apps/Minecraft Java Server/install
@@ -128,10 +128,10 @@ if [ -z "$server_version" ]; then
   # tell user to choose java 8, 16, or 17
   description="In order to run Minecraft, the game requires a specific version of Java.\
   \nPlease choose below which version of java the server of your choice should run with.\
-  \nJava versions can be 8, 16, or 17.\
+  \nJava versions can be 8 or 17.\
   \n\nAll versions of Minecraft before and including Minecraft 1.16.5 should use Java 8.\
-  \nMinecraft 1.17.X should use java 16 and Minecraft 1.18+ should use java 17."
-  table=("Java 17" "Java 16" "Java 8")
+  \nMinecraft 1.17+ should use java 17."
+  table=("Java 17" "Java 8")
   userinput_func "$description" "${table[@]}"
   java_selection="$output"
 else
@@ -144,10 +144,7 @@ else
   if [ $(version $server_version) -le $(version "1.16.5") ]; then
     echo "Using Java 8 by default"
     java_selection="Java 8"
-  elif [ $(version $server_version) -le $(version "1.17.1") ]; then
-    echo "Using Java 16 by default"
-    java_selection="Java 16"
-  elif [ $(version $server_version) -ge $(version "1.18") ]; then
+  elif [ $(version $server_version) -ge $(version "1.17") ]; then
     echo "Using Java 17 by default"
     java_selection="Java 17"
   else
@@ -157,7 +154,7 @@ else
     \nJava versions can be 8, 16, or 17.\
     \n\nAll version of Minecraft before and including Minecraft 1.16.5 should use Java 8.\
     \nMinecraft 1.17.X should use java 16 and Minecraft 1.18+ should use java 17."
-    table=("Java 17" "Java 16" "Java 8")
+    table=("Java 17" "Java 8")
     userinput_func "$description" "${table[@]}"
     java_selection="$output"
   fi
@@ -167,46 +164,7 @@ install_packages lsb-release wget gpg screen || exit 1
 
 case "$java_selection" in
   "Java 8"|"Java 17")
-    # temurin repo is NOW live
-    # add temurin repo for java 8/11/17
-    status "Adding Adoptium repository:"
-
-    echo "- public key -> keyring"
-    rm -f /tmp/adoptium-public-key /tmp/adoptium-archive-keyring.gpg
-    wget -O /tmp/adoptium-public-key https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public || exit 1
-    gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --import /tmp/adoptium-public-key || error "Failed to create a keyring with gpg"
-    rm -f /tmp/adoptium-public-key
-
-    echo " - keyring -> GPG key"
-    gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --export --output /tmp/adoptium-archive-keyring.gpg || error "Failed to create a GPG key"
-    rm -f /tmp/adoptium-keyring.gpg
-
-    echo " - Moving GPG key to /usr/share/keyrings"
-    sudo mv -f /tmp/adoptium-archive-keyring.gpg /usr/share/keyrings || error "Failed to move GPG key to /usr/share/keyrings"
-
-    echo " - Creating /etc/apt/sources.list.d/adoptium.list"
-    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb $(get_codename) main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
-    ;;
-  "Java 16")
-    # add old adoptopenjdk for java 16
-    status "Adding AdoptOpenJDK repository:"
-
-    echo "- public key -> keyring"
-
-    rm -f /tmp/adoptopenjdk-public-key /tmp/adoptopenjdk-archive-keyring.gpg
-    wget -O /tmp/adoptopenjdk-public-key https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public || exit 1
-    gpg --no-default-keyring --keyring /tmp/adoptopenjdk-keyring.gpg --import /tmp/adoptopenjdk-public-key || error "Failed to create a keyring with gpg"
-    rm -f /tmp/adoptopenjdk-public-key
-
-    echo " - keyring -> GPG key"
-    gpg --no-default-keyring --keyring /tmp/adoptopenjdk-keyring.gpg --export --output /tmp/adoptopenjdk-archive-keyring.gpg || error "Failed to create a GPG key"
-    rm -f /tmp/adoptopenjdk-keyring.gpg
-
-    echo " - Moving GPG key to /usr/share/keyrings"
-    sudo mv -f /tmp/adoptopenjdk-archive-keyring.gpg /usr/share/keyrings || error "Failed to move GPG key to /usr/share/keyrings"
-
-    echo " - Creating /etc/apt/sources.list.d/adoptopenjdk.list"
-    echo "deb [signed-by=/usr/share/keyrings/adoptopenjdk-archive-keyring.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb bionic main" | sudo tee /etc/apt/sources.list.d/adoptopenjdk.list >/dev/null
+    adoptium_installer || exit 1
     ;;
   *)
     error "No java version selected, exiting the script"
@@ -227,45 +185,11 @@ esac
 
 case "$java_selection" in
   "Java 8")
-    (install_packages temurin-8-jre)
-    if [ $? != 0 ]; then
-      if ! anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb" ; then
-        # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-        # safe to remove
-        sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
-        error "Failed to install temurin packages. Adoptium repository has been removed."
-      else
-        error "Failed to install temurin packages."
-      fi
-    fi
+    install_packages temurin-8-jre || exit 1
     java_location="/usr/lib/jvm/temurin-8-jre-$dpkg_arch/bin/java"
     ;;
-  "Java 16")
-    (install_packages adoptopenjdk-16-hotspot-jre)
-    if [ $? != 0 ]; then
-      if ! anything_installed_from_repo "https://adoptopenjdk.jfrog.io/adoptopenjdk/deb" ; then
-        # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-        # safe to remove
-        sudo rm -f /etc/apt/sources.list.d/adoptopenjdk.list /usr/share/keyrings/adoptopenjdk-archive-keyring.gpg
-        error "Failed to install adoptopenjdk packages. AdoptOpenJDK repository has been removed."
-      else
-        error "Failed to install adoptopenjdk packages."
-      fi
-    fi
-    java_location="/usr/lib/jvm/adoptopenjdk-16-hotspot-jre-$dpkg_arch/bin/java"
-    ;;
   "Java 17")
-    (install_packages temurin-17-jre)
-    if [ $? != 0 ]; then
-      if ! anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb" ; then
-        # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-        # safe to remove
-        sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
-        error "Failed to install temurin packages. Adoptium repository has been removed."
-      else
-        error "Failed to install temurin packages."
-      fi
-    fi
+    install_packages temurin-17-jre || exit 1
     java_location="/usr/lib/jvm/temurin-17-jre-$dpkg_arch/bin/java"
     ;;
 esac

--- a/apps/Pycharm CE/install-32
+++ b/apps/Pycharm CE/install-32
@@ -2,9 +2,10 @@
 
 version=2022.1.4
 
-install_packages python3-pip python3-dev openjdk-11-jdk build-essential clang || exit 1
+adoptium_installer || exit 1
+install_packages python3-pip python3-dev temurin-11-jdk build-essential clang || exit 1
 
-java_home="$(dpkg -L openjdk-11-jdk | grep "/usr/lib/jvm.*$(dpkg --print-architecture)$")"
+java_home="$(dpkg -L temurin-11-jdk | grep "/usr/lib/jvm.*$(dpkg --print-architecture)$")"
 
 wget https://download.jetbrains.com/python/pycharm-community-${version}.tar.gz -O pycharm-community.tar.gz || error "Failed to download pycharm-community.tar.gz"
 status "Extracting pycharm-community.tar.gz to /opt"

--- a/apps/Shattered Pixel Dungeon/install
+++ b/apps/Shattered Pixel Dungeon/install
@@ -2,15 +2,16 @@
 
 version=2.1.4
 
-install_packages openjdk-11-jre || exit 1
+adoptium_installer || exit 1
+install_packages temurin-17-jre || exit 1
 
 mkdir -p ~/.local/bin
 wget -O ~/.local/bin/ShatteredPD-Desktop.jar https://github.com/00-Evan/shattered-pixel-dungeon/releases/download/v${version}/ShatteredPD-v${version}-Java.jar || error "Could not download game!"
 
 
 case "$arch" in
-  "64") path=/usr/lib/jvm/java-11-openjdk-arm64/bin/java ;;
-  "32") path=/usr/lib/jvm/java-11-openjdk-armhf/bin/java ;;
+  "64") path=/usr/lib/jvm/temurin-17-jre-arm64/bin/java ;;
+  "32") path=/usr/lib/jvm/temurin-17-jre-armhf/bin/java ;;
   *) error "Failed to detect OS CPU architecture! Something is very wrong." ;;
 esac
 

--- a/apps/Shattered Pixel Dungeon/uninstall
+++ b/apps/Shattered Pixel Dungeon/uninstall
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 purge_packages || exit 1
+remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list
 
 rm -f ~/.local/share/applications/shatteredpd.desktop ~/.local/bin/ShatteredPD-Desktop.jar

--- a/apps/Unciv/install
+++ b/apps/Unciv/install
@@ -2,9 +2,6 @@
 
 version=4.7.9
 
-### Install dependencies
-install_packages lsb-release wget gpg || error "Failed to install dependencies"
-
 ### Make directory ~/Unciv if not available
 mkdir -p $HOME/Unciv || error "Failed to create folder $HOME/Unciv"
 
@@ -19,38 +16,8 @@ fi
 # so, we will use Temurin OpenJDK 8 installation cause thats the minimal Java version Unciv needs
 # Temurin very smoothly on Raspberry Pi 3B+ without any problems
 
-status "Adding Adoptium repository:"
-
-echo "- public key -> keyring"
-rm -f /tmp/adoptium-public-key /tmp/adoptium-archive-keyring.gpg
-wget -O /tmp/adoptium-public-key https://adoptium.jfrog.io/artifactory/api/security/keypair/default-gpg-key/public
-gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --import /tmp/adoptium-public-key
-rm -f /tmp/adoptium-public-key
-
-echo " - keyring -> GPG key"
-gpg --no-default-keyring --keyring /tmp/adoptium-keyring.gpg --export --output /tmp/adoptium-archive-keyring.gpg
-rm -f /tmp/adoptium-keyring.gpg
-
-echo " - Moving GPG key to /usr/share/keyrings"
-sudo mv -f /tmp/adoptium-archive-keyring.gpg /usr/share/keyrings
-
-echo " - Creating /etc/apt/sources.list.d/adoptium.list"
-echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://adoptium.jfrog.io/artifactory/deb $(get_codename) main" | sudo tee /etc/apt/sources.list.d/adoptium.list >/dev/null
-
-status "Installing temurin-8-jre"
-#try to install temurin-8-jre; if it fails, remove repository to avoid breaking user's system
-(install_packages temurin-8-jre)
-if [ $? != 0 ]; then
-  anything_installed_from_repo "https://adoptium.jfrog.io/artifactory/deb"
-  if [ $? != 0 ]; then
-    # nothing installed from repo, this check is to prevent removing repos which other pi-apps scripts or the user have used successfully
-    # safe to remove
-    sudo rm -f /etc/apt/sources.list.d/adoptium.list /usr/share/keyrings/adoptium-archive-keyring.gpg
-    error "Failed to install temurin packages. Adoptium repository has been removed."
-  else
-    error "Failed to install temurin packages."
-  fi
-fi
+adoptium_installer || exit 1
+install_packages temurin-8-jre || exit 1
 
 status "Downloading Unciv.jar"
 echo '- writing into /tmp/Unciv.jar'

--- a/apps/WorldPainter/install
+++ b/apps/WorldPainter/install
@@ -2,15 +2,16 @@
 
 version=2.18.4
 
-install_packages openjdk-11-jre https://www.worldpainter.net/files/worldpainter_${version}.deb || exit 1
+adoptium_installer || exit 1
+install_packages temurin-17-jre https://www.worldpainter.net/files/worldpainter_${version}.deb || exit 1
 
 # force java-11
 case "$arch" in
   "64")
-    echo /usr/lib/jvm/java-11-openjdk-arm64 | sudo tee /opt/worldpainter/.install4j/pref_jre.cfg >/dev/null
+    echo /usr/lib/jvm/temurin-17-jre-arm64 | sudo tee /opt/worldpainter/.install4j/pref_jre.cfg >/dev/null
     ;;
   "32")
-    echo /usr/lib/jvm/java-11-openjdk-armhf | sudo tee /opt/worldpainter/.install4j/pref_jre.cfg >/dev/null
+    echo /usr/lib/jvm/temurin-17-jre-armhf | sudo tee /opt/worldpainter/.install4j/pref_jre.cfg >/dev/null
     ;;
   *) error "Failed to detect OS CPU architecture! Something is very wrong." ;;
 esac

--- a/apps/WorldPainter/uninstall
+++ b/apps/WorldPainter/uninstall
@@ -3,3 +3,4 @@
 sudo rm -f /opt/worldpainter/.install4j/pref_jre.cfg
 
 purge_packages || exit 1
+remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list

--- a/apps/Xtreme Download Manager/install
+++ b/apps/Xtreme Download Manager/install
@@ -7,7 +7,8 @@ cd $HOME
 mkdir -p xdm 
 cd xdm
 
-install_packages openjdk-11-jdk ffmpeg || exit 1
+adoptium_installer || exit 1
+install_packages temurin-11-jre ffmpeg || exit 1
 
 wget -O xdm.tar.xz https://github.com/subhra74/xdm/releases/download/${version}/xdm-setup-${version}.tar.xz || error "Failed to download XDM setup tar file!"
 wget https://github.com/ytdl-org/youtube-dl/releases/download/${version2}/youtube-dl || error "Failed to download youtube-dl binary!"
@@ -18,15 +19,10 @@ sudo chmod +x ./youtube-dl
 sudo mv -f ./youtube-dl /opt/xdman || error "Failed to copy youtube-dl binary!"
 
 # Use system java
-if [ -d $(dirname $(dirname $(sudo update-alternatives --list java | grep 'java-11-openjdk' --color=none))) ]; then
-	sudo rm -rf /opt/xdman/jre/*
-	sudo cp -r $(dirname $(dirname $(sudo update-alternatives --list java | grep 'java-11-openjdk' --color=none)))/* /opt/xdman/jre/
-elif command -v java &>/dev/null; then
-	sudo sed -i s=/opt/xdman/jre/bin/java=$(command -v java)=g /opt/xdman/xdman || error "Failed to change to system Java runtime in /opt/xdman/xdman!"
-	sudo sed -i s=/opt/xdman/jre/bin/java=$(command -v java)=g /usr/bin/xdman || error "Failed to change to system Java runtime in /usr/bin/xdman!"
-else
-	error "OpenJDK-11 installation not found!"
-fi
+sudo rm -rf /opt/xdman/jre
+sudo sed -i s=/opt/xdman/jre/bin/java=$(echo /usr/lib/jvm/temurin-11-jre-*/bin/java)=g /opt/xdman/xdman || error "Failed to change to system Java runtime in /opt/xdman/xdman!"
+sudo sed -i s=/opt/xdman/jre/bin/java=$(echo /usr/lib/jvm/temurin-11-jre-*/bin/java)=g /usr/bin/xdman || error "Failed to change to system Java runtime in /usr/bin/xdman!"
+
 # Fix 'Download failed. Failed to append/convert file parts, please check if the drive is full or write protected'
 sudo cp -f $(command -v ffmpeg) /opt/xdman || error "Failed to copy ffmpeg binary!"
 # Delete unwanted files after installation

--- a/apps/Xtreme Download Manager/uninstall
+++ b/apps/Xtreme Download Manager/uninstall
@@ -1,5 +1,6 @@
 #!/bin/bash
 purge_packages || exit 1
+remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list
 
 sudo rm -rf /opt/xdman || error "Failed to remove /opt/xdman/ directpry!"
 sudo rm -f /usr/share/applications/xdman.desktop || error "Failed to remove menu shortcut!"

--- a/apps/jGRASP IDE/install
+++ b/apps/jGRASP IDE/install
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 #get java
-install_packages openjdk-11-jdk || exit 1
+adoptium_installer || exit 1
+install_packages temurin-11-jdk || exit 1
 
 rm -rf ~/jgrasp.zip ~/jgrasp
 

--- a/apps/jGRASP IDE/uninstall
+++ b/apps/jGRASP IDE/uninstall
@@ -3,3 +3,4 @@ rm -rf ~/jgrasp.zip ~/jgrasp
 
 
 purge_packages || exit 1
+remove_repofile_if_unused /etc/apt/sources.list.d/adoptium.list

--- a/gui
+++ b/gui
@@ -287,7 +287,7 @@ generate_logo &
 
 #install dependencies
 runonce <<"EOF"
-  dependencies='yad curl wget aria2 lsb-release software-properties-common apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils rsync'
+  dependencies='yad curl wget aria2 lsb-release software-properties-common apt-utils apt-transport-https gnupg imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils rsync'
   # Install dependencies if necessary
   if ! dpkg -s $dependencies >/dev/null 2>&1; then
     sudo_popup apt install $dependencies -y -f --no-install-recommends

--- a/install
+++ b/install
@@ -23,7 +23,7 @@ fi
 sudo apt update || error "The command 'sudo apt update' failed. Before Pi-Apps will work, you must fix your apt package-management system."
 
 #install dependencies
-dependencies='yad curl wget aria2 lsb-release software-properties-common apt-utils imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils rsync'
+dependencies='yad curl wget aria2 lsb-release software-properties-common apt-utils apt-transport-https gnupg imagemagick bc librsvg2-bin locales shellcheck git wmctrl xdotool x11-utils rsync'
 
 if ! dpkg -s $dependencies &>/dev/null ;then
   sudo apt install $dependencies -y -f --no-install-recommends


### PR DESCRIPTION
switches to temurin java from openjdk due to openjdk 8/11 having been removed in bookworm.

Some install scripts had cases specific to ubuntu to use openjdk so those have been left since ubuntu shows no interest in removing any openjdk LTS (8/11/17) from their distros.