### PR TITLE
Anydesk arm64

### DIFF
--- a/api
+++ b/api
@@ -109,14 +109,19 @@ package_installed() { #exit 0 if $1 package is installed, otherwise exit 1
   grep "^Package: $package$" /var/lib/dpkg/status -A 1 | tail -n 1 | grep -q 'Status: install ok installed'
 }
 
-package_available() { #determine if the specified package-name exists in a repository
-  local package="$1"
+package_available() { #determine if the specified package-name exists in a local repository for the current dpkg architecture
+  local package="$(awk -F: '{print $1}' <<<"$1")"
+  local dpkg_arch="$(awk -F: '{print $2}' <<<"$2")"
+  [ -z "$dpkg_arch" ] && dpkg_arch="$(dpkg --print-architecture)"
   [ -z "$package" ] && error "package_available(): no package name specified!"
-  #using find and grep to do this is nearly instantaneous, rather than apt-cache which takes several seconds
-  local IFS=$'\n'
-  for file in $(find /var/lib/apt/lists -maxdepth 1 -type f -name "*_Packages") ;do
-    grep -q "^Package: $package$" "$file" && break
-  done
+  local output="$(apt-cache policy "$package":"$dpkg_arch" | grep "Candidate:")"
+  if [ -z "$output" ]; then
+    return 1
+  elif echo "$output" | grep -q "Candidate: (none)"; then
+    return 1
+  else
+    return 0
+  fi
 }
 
 package_dependencies() { #outputs the list of dependencies for the $1 package

--- a/api
+++ b/api
@@ -401,11 +401,20 @@ install_packages() { #Make some packages dependencies of the $app app. Package-n
       
       [ -f "$package" ] || error "install_packages(): Local package does not exist! ($package)"
       
-      #determine the package name from the filename
-      packagename="$(dpkg-deb -I "$package" | grep "^ Package:" | awk '{print $2}')"
-      packageversion="$(dpkg-deb -I "$package" | grep "^ Version:" | awk '{print $2}')"
-      [ -z "$packagename" ] && error "install_packages(): failed to determine a package-name for the file '$package'"
-      [ -z "$packageversion" ] && error "install_packages(): failed to determine a package-version for the file '$package'"
+      #determine the package name, package version, and architecture from the file
+      local dpkg_deb_output="$(dpkg-deb -I "$filename")"
+      local packagename="$(echo "$dpkg_deb_output" | grep "^ Package:" | awk '{print $2}')"
+      local packageversion="$(echo "$dpkg_deb_output" | grep "^ Version:" | awk '{print $2}')"
+      local packagearch="$(echo "$dpkg_deb_output" | grep "^ Architecture:" | awk '{print $2}')"
+      [ -z "$packagename" ] && error "install_packages(): failed to determine a package-name for the file '$filename'"
+      [ -z "$packageversion" ] && error "install_packages(): failed to determine a package-version for the file '$filename'"
+      [ -z "$packagearch" ] && error "install_packages(): failed to determine a package-architecture for the file '$filename'"
+      unset dpkg_deb_output
+      
+      #foreign arch: add :armhf or :arm64 to the packagename if this local package is of a foreign architecture
+      if [ "$packagearch" != "$(dpkg --print-architecture)" ];then
+        packagename+=":$packagearch"
+      fi
       
       #add this local package to the pi-apps-local-packages repository
       repo_add "$package" || return 1
@@ -429,11 +438,20 @@ install_packages() { #Make some packages dependencies of the $app app. Package-n
       
       wget -O "$filename" "$package" || return 1
       
-      #determine the package name from the filename
-      packagename="$(dpkg-deb -I "$filename" | grep "^ Package:" | awk '{print $2}')"
-      packageversion="$(dpkg-deb -I "$filename" | grep "^ Version:" | awk '{print $2}')"
+      #determine the package name, package version, and architecture from the file
+      local dpkg_deb_output="$(dpkg-deb -I "$filename")"
+      local packagename="$(echo "$dpkg_deb_output" | grep "^ Package:" | awk '{print $2}')"
+      local packageversion="$(echo "$dpkg_deb_output" | grep "^ Version:" | awk '{print $2}')"
+      local packagearch="$(echo "$dpkg_deb_output" | grep "^ Architecture:" | awk '{print $2}')"
       [ -z "$packagename" ] && error "install_packages(): failed to determine a package-name for the file '$filename'"
       [ -z "$packageversion" ] && error "install_packages(): failed to determine a package-version for the file '$filename'"
+      [ -z "$packagearch" ] && error "install_packages(): failed to determine a package-architecture for the file '$filename'"
+      unset dpkg_deb_output
+      
+      #foreign arch: add :armhf or :arm64 to the packagename if this local package is of a foreign architecture
+      if [ "$packagearch" != "$(dpkg --print-architecture)" ];then
+        packagename+=":$packagearch"
+      fi
       
       #add this local package to the pi-apps-local-packages repository
       repo_add "$filename" || return 1

--- a/apps/AnyDesk/install-64
+++ b/apps/AnyDesk/install-64
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+version=6.3.0-1
+
+function check-armhf() {
+	ARMHF="$(dpkg --print-foreign-architectures | grep "armhf")"
+}
+
+#add armhf architecture (multiarch)
+check-armhf
+if [[ "$ARMHF" == *"armhf"* ]]; then
+  echo "armhf arcitecture already added..."
+else
+  sudo dpkg --add-architecture armhf
+  check-armhf
+  if [[ "$ARMHF" != *"armhf"* ]]; then
+    error "armhf architecture should be added by now, but it isn't!"
+  fi
+fi
+
+unset rpi_arm_userspace
+# only install the libraspberrypi0 arm32 package if the user already has the libraspberrypi0 arm64 package installed
+if package_installed libraspberrypi0 ; then
+  rpi_arm_userspace="libraspberrypi0:armhf"
+fi
+
+install_packages https://download.anydesk.com/rpi/anydesk_${version}_armhf.deb libgles-dev:armhf libegl-dev:armhf libpolkit-gobject-1-0:armhf $rpi_arm_userspace || exit 1
+
+#As libraspberrypi-dev:armhf cannot be installed with multiarch, symlink the required libs from libraspberrypi0:armhf
+if [ -e /usr/lib/arm-linux-gnueabihf/libbcm_host.so.0 ] && [ -e /usr/lib/arm-linux-gnueabihf/libvcos.so.0 ] && [ -e /usr/lib/arm-linux-gnueabihf/libvchiq_arm.so.0 ];then
+  sudo ln -s /usr/lib/arm-linux-gnueabihf/libbcm_host.so.0 /usr/lib/arm-linux-gnueabihf/libbcm_host.so
+  sudo ln -s /usr/lib/arm-linux-gnueabihf/libvcos.so.0 /usr/lib/arm-linux-gnueabihf/libvcos.so
+  sudo ln -s /usr/lib/arm-linux-gnueabihf/libvchiq_arm.so.0 /usr/lib/arm-linux-gnueabihf/libvchiq_arm.so
+else
+  error "Could not locate needed libs to symlink! Please ask pi-apps developers for help about this."
+fi
+# Solve error on Bullseye: "anydesk: error while loading shared libraries: libbrcmGLESv2.so: cannot open shared object file: No such file or directory"
+
+[ ! -e /usr/lib/libbrcmGLESv2.so ] && sudo ln -s /usr/lib/arm-linux-gnueabihf/libGLESv2.so /usr/lib/arm-linux-gnueabihf/libbrcmGLESv2.so
+[ ! -e /usr/lib/libbrcmEGL.so ] && sudo ln -s /usr/lib/arm-linux-gnueabihf/libEGL.so /usr/lib/arm-linux-gnueabihf/libbrcmEGL.so
+exit 0

--- a/apps/AnyDesk/install-64
+++ b/apps/AnyDesk/install-64
@@ -24,18 +24,19 @@ if package_installed libraspberrypi0 ; then
   rpi_arm_userspace="libraspberrypi0:armhf"
 fi
 
-install_packages https://download.anydesk.com/rpi/anydesk_${version}_armhf.deb libgles-dev:armhf libegl-dev:armhf libpolkit-gobject-1-0:armhf $rpi_arm_userspace || exit 1
+install_packages https://download.anydesk.com/rpi/anydesk_${version}_armhf.deb libgles-dev:armhf libegl-dev:armhf libpolkit-gobject-1-0:armhf $rpi_arm_userspace patchelf || exit 1
 
-#As libraspberrypi-dev:armhf cannot be installed with multiarch, symlink the required libs from libraspberrypi0:armhf
-if [ -e /usr/lib/arm-linux-gnueabihf/libbcm_host.so.0 ] && [ -e /usr/lib/arm-linux-gnueabihf/libvcos.so.0 ] && [ -e /usr/lib/arm-linux-gnueabihf/libvchiq_arm.so.0 ];then
-  sudo ln -s /usr/lib/arm-linux-gnueabihf/libbcm_host.so.0 /usr/lib/arm-linux-gnueabihf/libbcm_host.so
-  sudo ln -s /usr/lib/arm-linux-gnueabihf/libvcos.so.0 /usr/lib/arm-linux-gnueabihf/libvcos.so
-  sudo ln -s /usr/lib/arm-linux-gnueabihf/libvchiq_arm.so.0 /usr/lib/arm-linux-gnueabihf/libvchiq_arm.so
-else
-  error "Could not locate needed libs to symlink! Please ask pi-apps developers for help about this."
-fi
-# Solve error on Bullseye: "anydesk: error while loading shared libraries: libbrcmGLESv2.so: cannot open shared object file: No such file or directory"
+#make anydesk search armhf libs first
+sudo patchelf --set-rpath /usr/lib/arm-linux-gnueabihf /usr/bin/anydesk
 
-[ ! -e /usr/lib/libbrcmGLESv2.so ] && sudo ln -s /usr/lib/arm-linux-gnueabihf/libGLESv2.so /usr/lib/arm-linux-gnueabihf/libbrcmGLESv2.so
-[ ! -e /usr/lib/libbrcmEGL.so ] && sudo ln -s /usr/lib/arm-linux-gnueabihf/libEGL.so /usr/lib/arm-linux-gnueabihf/libbrcmEGL.so
-exit 0
+#libraspberrypi0:armhf provides libs with so.0, but it is not multiarch compatible
+#so patch anydesk to use equivalent .so libs from libraspberrypi-dev:armhf
+
+sudo patchelf --replace-needed libbcm_host.so libbcm_host.so.0 /usr/bin/anydesk
+sudo patchelf --replace-needed libvcos.so libvcos.so.0 /usr/bin/anydesk
+sudo patchelf --replace-needed libvchiq_arm.so libvchiq_arm.so.0 /usr/bin/anydesk
+
+# Solve error: "anydesk: error while loading shared libraries: libbrcmGLESv2.so: cannot open shared object file: No such file or directory"
+
+sudo patchelf --replace-needed libbrcmGLESv2.so libGLESv2.so /usr/bin/anydesk
+sudo patchelf --replace-needed libbrcmEGL.so libEGL.so /usr/bin/anydesk

--- a/apps/AnyDesk/install-64
+++ b/apps/AnyDesk/install-64
@@ -9,7 +9,7 @@ function check-armhf() {
 #add armhf architecture (multiarch)
 check-armhf
 if [[ "$ARMHF" == *"armhf"* ]]; then
-  echo "armhf arcitecture already added..."
+  echo "armhf architecture already added..."
 else
   sudo dpkg --add-architecture armhf
   check-armhf
@@ -19,12 +19,12 @@ else
 fi
 
 unset rpi_arm_userspace
-# only install the libraspberrypi0 arm32 package if the user already has the libraspberrypi0 arm64 package installed
-if package_installed libraspberrypi0 ; then
-  rpi_arm_userspace="libraspberrypi0:armhf"
+
+if ! package_available libraspberrypi0:armhf ; then
+  error "AnyDesk needs some system libraries specific to the Raspberry Pi, but on your system the libraspberrypi0:armhf package does not seem to be available."
 fi
 
-install_packages https://download.anydesk.com/rpi/anydesk_${version}_armhf.deb libgles-dev:armhf libegl-dev:armhf libpolkit-gobject-1-0:armhf $rpi_arm_userspace patchelf || exit 1
+install_packages https://download.anydesk.com/rpi/anydesk_${version}_armhf.deb libgles2:armhf libegl1:armhf libpolkit-gobject-1-0:armhf libraspberrypi0:armh patchelf || exit 1
 
 #make anydesk search armhf libs first
 sudo patchelf --set-rpath /usr/lib/arm-linux-gnueabihf /usr/bin/anydesk
@@ -36,7 +36,10 @@ sudo patchelf --replace-needed libbcm_host.so libbcm_host.so.0 /usr/bin/anydesk
 sudo patchelf --replace-needed libvcos.so libvcos.so.0 /usr/bin/anydesk
 sudo patchelf --replace-needed libvchiq_arm.so libvchiq_arm.so.0 /usr/bin/anydesk
 
-# Solve error: "anydesk: error while loading shared libraries: libbrcmGLESv2.so: cannot open shared object file: No such file or directory"
+#use gl libraries from lib deps to avoid needing to install -dev variants
+sudo patchelf --replace-needed libGLESv2.so libGLESv2.so.2 /usr/bin/anydesk
+sudo patchelf --replace-needed libEGL.so libEGL.so.1 /usr/bin/anydesk
 
+# Solve error: "anydesk: error while loading shared libraries: libbrcmGLESv2.so: cannot open shared object file: No such file or directory"
 sudo patchelf --replace-needed libbrcmGLESv2.so libGLESv2.so /usr/bin/anydesk
 sudo patchelf --replace-needed libbrcmEGL.so libEGL.so /usr/bin/anydesk

--- a/apps/AnyDesk/install-64
+++ b/apps/AnyDesk/install-64
@@ -29,8 +29,8 @@ install_packages https://download.anydesk.com/rpi/anydesk_${version}_armhf.deb l
 #make anydesk search armhf libs first
 sudo patchelf --set-rpath /usr/lib/arm-linux-gnueabihf /usr/bin/anydesk
 
-#libraspberrypi0:armhf provides libs with so.0, but it is not multiarch compatible
-#so patch anydesk to use equivalent .so libs from libraspberrypi-dev:armhf
+#libraspberrypi0:armhf provides libs with so.0, but anydesk wants libs that end in .so
+#fix it
 
 sudo patchelf --replace-needed libbcm_host.so libbcm_host.so.0 /usr/bin/anydesk
 sudo patchelf --replace-needed libvcos.so libvcos.so.0 /usr/bin/anydesk

--- a/apps/AnyDesk/uninstall
+++ b/apps/AnyDesk/uninstall
@@ -2,6 +2,20 @@
 
 purge_packages || exit 1
 
+if [ "$arch" == 64 ];then
+  # remove armhf architecture if no packages from it are currently installed
+  apt list --installed | awk '$3 == "armhf" { print }' | grep -q installed || sudo dpkg --remove-architecture armhf
+  
+  #unlink libs
+  IFS=' '
+  for i in /usr/lib/arm-linux-gnueabihf/libbcm_host.so /usr/lib/arm-linux-gnueabihf/libvcos.so /usr/lib/arm-linux-gnueabihf/libvchiq_arm.so /usr/lib/arm-linux-gnueabihf/libbrcmGLESv2.so /usr/lib/arm-linux-gnueabihf/libbrcmEGL.so ;do
+    if [ -L $i ];then
+      sudo rm -f $i
+    fi
+  done
+  
+fi
+
 #remove symlinked libraries
 if [ -L /usr/lib/libbrcmGLESv2.so ];then
   sudo rm -f /usr/lib/libbrcmGLESv2.so

--- a/apps/AnyDesk/uninstall
+++ b/apps/AnyDesk/uninstall
@@ -5,15 +5,6 @@ purge_packages || exit 1
 if [ "$arch" == 64 ];then
   # remove armhf architecture if no packages from it are currently installed
   apt list --installed | awk '$3 == "armhf" { print }' | grep -q installed || sudo dpkg --remove-architecture armhf
-  
-  #unlink libs
-  IFS=' '
-  for i in /usr/lib/arm-linux-gnueabihf/libbcm_host.so /usr/lib/arm-linux-gnueabihf/libvcos.so /usr/lib/arm-linux-gnueabihf/libvchiq_arm.so /usr/lib/arm-linux-gnueabihf/libbrcmGLESv2.so /usr/lib/arm-linux-gnueabihf/libbrcmEGL.so ;do
-    if [ -L $i ];then
-      sudo rm -f $i
-    fi
-  done
-  
 fi
 
 #remove symlinked libraries


### PR DESCRIPTION
Testing required on systems other than PiOS Bullseye 64-bit.

This uses multiarch and some dirty lib symlinking to get Anydesk running on PiOS 64-bit. It avoids installing libraspberrypi-dev:armhf, as that package conflicts with libraspberrypi-dev:arm64.

I doubt Anydesk would successfully open on a system other than PiOS due to missing libs.