### PR TITLE
Increase minimum supported versions of Debian to Bullseye (11) and Ubuntu to Focal (20.04)

### DIFF
--- a/api
+++ b/api
@@ -2555,8 +2555,11 @@ apt.armbian.com")"
   elif cat /proc/version | grep -qi Microsoft || cat /proc/sys/kernel/osrelease | grep -qi WSL || [[ -f "/run/WSL" ]] || [[ -f "/etc/wsl.conf" ]] || [ -n "$WSL_DISTRO_NAME" ]; then
     echo "Pi-Apps is not supported on WSL."
     return 1
-  elif ([ "$__os_id" == "Debian" ] || [ "$__os_id" == "Raspbian" ]) && ! printf '%s\n' "11" "$__os_release" | sort -CV ; then
+  elif ([ "$__os_id" == "Debian" ] || [ "$__os_id" == "Raspbian" ]) && ! printf '%s\n' "10" "$__os_release" | sort -CV ; then
     echo "Pi-Apps is not supported on your outdated $__os_id $__os_release operating system. Expect many apps to fail. Consider upgrading your operating system."
+    return 1
+  elif [ "$__os_id" == "Raspbian" ] && ! printf '%s\n' "11" "$__os_release" | sort -CV ; then
+    echo "Pi-Apps is no longer supported on your Pi OS $__os_release operating system. Consider upgrading to Pi OS Bookworm. https://www.raspberrypi.com/news/bookworm-the-new-version-of-raspberry-pi-os/"
     return 1
   elif [ "$__os_id" == "Ubuntu" ] && ! printf '%s\n' "20.04" "$__os_release" | sort -CV ; then
     echo "Pi-Apps is not supported on your outdated $__os_id $__os_release operating system. Expect many apps to fail. Consider upgrading your operating system."

--- a/api
+++ b/api
@@ -2555,11 +2555,11 @@ apt.armbian.com")"
   elif cat /proc/version | grep -qi Microsoft || cat /proc/sys/kernel/osrelease | grep -qi WSL || [[ -f "/run/WSL" ]] || [[ -f "/etc/wsl.conf" ]] || [ -n "$WSL_DISTRO_NAME" ]; then
     echo "Pi-Apps is not supported on WSL."
     return 1
-  elif ([ "$__os_id" == "Debian" ] || [ "$__os_id" == "Raspbian" ]) && ! printf '%s\n' "10" "$__os_release" | sort -CV ; then
-    echo "Pi-Apps is not supported on your outdated $__os_id $__os_release operating system. Expect many apps to fail. Consider upgrading your operating system."
+  elif ([ "$__os_id" == "Debian" ] || [ "$__os_id" == "Raspbian" ]) && [ -f /etc/rpi-issue ] && [ "$__os_release" == 10 ]; then
+    echo "Pi-Apps is no longer supported on your Pi OS Buster operating system. Consider upgrading to Pi OS Bookworm. https://www.raspberrypi.com/news/bookworm-the-new-version-of-raspberry-pi-os/"
     return 1
-  elif [ "$__os_id" == "Raspbian" ] && ! printf '%s\n' "11" "$__os_release" | sort -CV ; then
-    echo "Pi-Apps is no longer supported on your Pi OS $__os_release operating system. Consider upgrading to Pi OS Bookworm. https://www.raspberrypi.com/news/bookworm-the-new-version-of-raspberry-pi-os/"
+  elif ([ "$__os_id" == "Debian" ] || [ "$__os_id" == "Raspbian" ]) && ! printf '%s\n' "11" "$__os_release" | sort -CV ; then
+    echo "Pi-Apps is not supported on your outdated $__os_id $__os_release operating system. Expect many apps to fail. Consider upgrading your operating system."
     return 1
   elif [ "$__os_id" == "Ubuntu" ] && ! printf '%s\n' "20.04" "$__os_release" | sort -CV ; then
     echo "Pi-Apps is not supported on your outdated $__os_id $__os_release operating system. Expect many apps to fail. Consider upgrading your operating system."

--- a/api
+++ b/api
@@ -2555,10 +2555,10 @@ apt.armbian.com")"
   elif cat /proc/version | grep -qi Microsoft || cat /proc/sys/kernel/osrelease | grep -qi WSL || [[ -f "/run/WSL" ]] || [[ -f "/etc/wsl.conf" ]] || [ -n "$WSL_DISTRO_NAME" ]; then
     echo "Pi-Apps is not supported on WSL."
     return 1
-  elif ([ "$__os_id" == "Debian" ] || [ "$__os_id" == "Raspbian" ]) && ! printf '%s\n' "10" "$__os_release" | sort -CV ; then
+  elif ([ "$__os_id" == "Debian" ] || [ "$__os_id" == "Raspbian" ]) && ! printf '%s\n' "11" "$__os_release" | sort -CV ; then
     echo "Pi-Apps is not supported on your outdated $__os_id $__os_release operating system. Expect many apps to fail. Consider upgrading your operating system."
     return 1
-  elif [ "$__os_id" == "Ubuntu" ] && ! printf '%s\n' "18.04" "$__os_release" | sort -CV ; then
+  elif [ "$__os_id" == "Ubuntu" ] && ! printf '%s\n' "20.04" "$__os_release" | sort -CV ; then
     echo "Pi-Apps is not supported on your outdated $__os_id $__os_release operating system. Expect many apps to fail. Consider upgrading your operating system."
     return 1
   elif echo "$PRETTY_NAME" | grep -qi 'manjaro'; then


### PR DESCRIPTION
To ease development and encourage upstream movement of our users, keep a past two LTS release support status.

I am not really interested in actively removing buster/bionic from all scripts immediately but we will just no longer consider needing support for them a blocker. Future scripts and script updates can support buster/bionic at their discretion but it will not be required or encouraged.