### PR TITLE
Switch MCPI-Reborn To Downloading From Gitea

### DIFF
--- a/.github/workflows/updates/Minecraft Pi (Modded).sh
+++ b/.github/workflows/updates/Minecraft Pi (Modded).sh
@@ -2,17 +2,10 @@
 
 # To avoid writing a custom updater script for this application, we will combine the separate version IDs used in the one URL as one large version variable.
 
-# Build ID
-# This obtains the latest successful build ID.
-build_id="$(curl -s --connect-timeout 15 https://jenkins.thebrokenrail.com/job/minecraft-pi-reborn/job/master/lastStableBuild/buildNumber)"
+# Version
+webVer="$(curl -s --connect-timeout 15 -X 'GET' 'https://gitea.thebrokenrail.com/api/v1/repos/minecraft-pi-reborn/minecraft-pi-reborn/releases/latest' -H 'accept: application/json' | jq --compact-output --raw-output '.tag_name')"
 
-# Version Number
-# This obtains the latest successful build's version number.
-deb_id="$(curl -s --connect-timeout 15 "https://jenkins.thebrokenrail.com/job/minecraft-pi-reborn/job/master/${build_id}/api/json?tree=artifacts%5BrelativePath%5D" | jq | grep 'client-.*-arm64.AppImage"' | sed 's/.*client-//g' | sed 's/-arm64.*//g')"
-
-# Update
-[ ! -z "$build_id" ] && [ ! -z "$deb_id" ] && webVer="${build_id}/artifact/out/minecraft-pi-reborn-client-${deb_id}"
 # This URL is only used for validation.
-armhf_url="https://jenkins.thebrokenrail.com/job/minecraft-pi-reborn/job/master/${webVer}-armhf.AppImage"
-arm64_url="https://jenkins.thebrokenrail.com/job/minecraft-pi-reborn/job/master/${webVer}-arm64.AppImage"
+armhf_url="https://gitea.thebrokenrail.com/minecraft-pi-reborn/minecraft-pi-reborn/releases/download/${webVer}/minecraft-pi-reborn-client-${webVer}-armhf.AppImage"
+arm64_url="https://gitea.thebrokenrail.com/minecraft-pi-reborn/minecraft-pi-reborn/releases/download/${webVer}/minecraft-pi-reborn-client-${webVer}-arm64.AppImage"
 source "${GITHUB_WORKSPACE}/.github/workflows/update_github_script.sh"

--- a/apps/Minecraft Pi (Modded)/install
+++ b/apps/Minecraft Pi (Modded)/install
@@ -1,7 +1,30 @@
 #!/bin/bash
 
+# https://github.com/raspberrypi/bookworm-feedback/issues/107
+PAGE_SIZE="$(getconf PAGE_SIZE)"
+if [[ "$PAGE_SIZE" == "16384" ]]; then
+    #switch to 4K pagesize kernel
+    if [ -f /boot/config.txt ]; then
+        text="Raspberry Pi 5 PiOS images ship by default with a 16K PageSize Linux Kernel.
+        This kernel causes incompatibilities with some software including MCPI-Reborn https://github.com/raspberrypi/bookworm-feedback/issues/107
+
+        Would you like to automatically switch to a 4K PageSize Linux Kernel?"
+        userinput_func "$text" "No, keep 16K PageSize Kernel and Exit" "Yes, switch to 4K PageSize Kernel"
+        if [ "$output" == "No, keep 16K PageSize Kernel and Exit" ]; then
+            error "User error: Your current running kernel is built with 16K PageSize and is incompatible with MCPI-Reborn. You must switch to a 4K PageSize kernel (and chose to not do so automatically) before installing MCPI-Reborn."
+        fi
+        echo "" | sudo tee --append /boot/config.txt >/dev/null
+        echo "[pi5]" | sudo tee --append /boot/config.txt >/dev/null
+        echo "kernel=kernel8.img" | sudo tee --append /boot/config.txt >/dev/null
+        echo -e "The 4K PageSize Kernel has been enabled by adding 'kernel=kernel8.img' to /boot/config.txt\nPlease reboot and install the QEMU app again."
+        sleep infinity
+    else
+        error "User error (reporting allowed): Your current running kernel is built with 16K PageSize and is incompatible with QEMU. Changing kernels automatically cannot be done since no /boot/config.txt file was found."
+    fi
+fi
+
 # Version
-version=288/artifact/out/minecraft-pi-reborn-client-2.5.1
+version=2.5.2
 
 # Install
 if [ "${arch}" = "64" ]; then
@@ -9,7 +32,7 @@ if [ "${arch}" = "64" ]; then
 else
     url_arch=armhf
 fi
-url="https://jenkins.thebrokenrail.com/job/minecraft-pi-reborn/job/master/${version}-${url_arch}.AppImage"
+url="https://gitea.thebrokenrail.com/minecraft-pi-reborn/minecraft-pi-reborn/releases/download/${version}/minecraft-pi-reborn-client-${version}-${url_arch}.AppImage"
 
 # Cleanup Old Script Versions
 sudo rm -f /etc/apt/trusted.gpg.d/mcpi-revival.gpg


### PR DESCRIPTION
With MCPI-Reborn v2.5.2, releases are now uploaded to [Gitea Releases](https://gitea.thebrokenrail.com/minecraft-pi-reborn/minecraft-pi-reborn/releases) using Gitea Actions instead of Jenkins. This was done because Jenkins was, quite frankly, terrible, kept breaking, and was probably also a security risk.

There are still files on https://jenkins.thebrokenrail.com to prevent scripts from breaking, but newer version will only be on Gitea.