### PR TITLE
Update Pychess to 1.0.5

### DIFF
--- a/apps/PyChess/install
+++ b/apps/PyChess/install
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-version=1.0.3
+version=1.0.5
 
 install_packages "https://github.com/pychess/pychess/releases/download/${version}/python3-pychess_${version}-1_all.deb" || exit 1


### PR DESCRIPTION
Pychess released version 1.0.5 a few hours ago.

* https://github.com/pychess/pychess/releases/tag/1.0.5

This PR requests the update of this new version in the application installer.

**Testing** 

* Verified that the new version works correctly on Raspberry Pi 5 by running the latest version of the Raspberry Pi OS.

* Confirmed that no errors occur in the installation.