### PR TITLE
Tidy up settings script

### DIFF
--- a/settings
+++ b/settings
@@ -36,6 +36,14 @@ revert) # Overwrite all settings with the defaults.
   done
   exit 0
   ;;
+*)
+  printf "\
+Usage: %s (subcommand)
+\t%s - Start the settings GUI.
+\t%s refresh - Set default settings, if they don't exist.
+\t%s revert  - Overwrite all settings with the defaults.
+" "$0" "$0" "$0" "$0" >&2
+  exit 64 # EX_USAGE
 esac
 
 if [ ! -f ~/.local/share/applications/pi-apps-settings.desktop ];then

--- a/settings
+++ b/settings
@@ -32,14 +32,10 @@ if [ "$1" == 'refresh' ];then
 elif [ "$1" == 'revert' ];then #If $1 equals 'revert', then overwrite all settings with the defaults and then the script will exit.
   
   #overwrite all settings with the defaults
-  settings="$(ls "${DIRECTORY}/etc/setting-params" | tr '\n' '|')"
-  PREIFS="$IFS"
-  IFS='|'
-  for name in $settings
+  for setting in "$DIRECTORY"/etc/setting/params/*
   do
-    cat "${DIRECTORY}/etc/setting-params/${name}" | grep -v '#' | head -n1 > "${DIRECTORY}/data/settings/${name}"
+    <"$setting" grep -v '#' | head -n 1 >"$DIRECTORY"/data/settings/"$(basename "$setting")"
   done
-  IFS="$PREIFS"
   exit 0
 fi
 

--- a/settings
+++ b/settings
@@ -21,8 +21,10 @@ if [ "$1" == 'refresh' ];then
   #set default settings, if they don't exist
   for setting in "$DIRECTORY"/etc/setting-params/*
   do
-    if ! test -f "$DIRECTORY"/data/settings/"$name" || wc -c <"$DIRECTORY"/data/settings/"$name" | xargs test 0 =;then
-      <"$DIRECTORY"/etc/setting-params/"$name" grep -v '#' | head -n 1 >"$DIRECTORY"/data/settings/"$name"
+    if ! test -f "$DIRECTORY"/data/settings/"$(basename "$setting")" \
+        || wc -c <"$DIRECTORY"/data/settings/"$(basename "$setting")" \
+          | xargs test 0 =;then
+      <"$setting" grep -v '#' | head -n 1 >"$DIRECTORY"/data/settings/"$(basename "$setting")"
     fi
   done
   exit 0
@@ -180,8 +182,8 @@ for setting in "$DIRECTORY"/etc/setting-params/*
 do
   printf '%s\n' "$output" \
     | sed -n "${settingnumber}p" \
-    | tee "$DIRECTORY/data/settings/$name" \
-    | xargs printf 'Set "%s" to "%s\n"' "$setting"
+    | tee "$DIRECTORY/data/settings/$(basename "$setting")" \
+    | xargs printf 'Set "%s" to "%s\n"' "$(basename "$setting")"
 
   settingnumber=$(printf '1 + %s\n' "$settingnumber" | bc)
 done

--- a/settings
+++ b/settings
@@ -19,16 +19,12 @@ fi
 #$1 is usually left blank. If it equals 'refresh', then empty settings will be created and then the script will exit.
 if [ "$1" == 'refresh' ];then
   #set default settings, if they don't exist
-  settings="$(ls "${DIRECTORY}/etc/setting-params" | tr '\n' '|')"
-  PREIFS="$IFS"
-  IFS='|'
-  for name in $settings
+  for setting in "$DIRECTORY"/etc/setting-params/*
   do
-    if [ ! -f "${DIRECTORY}/data/settings/${name}" ] || [ -z "$(cat "${DIRECTORY}/data/settings/${name}")" ];then
-      cat "${DIRECTORY}/etc/setting-params/${name}" | grep -v '#' | head -n1 > "${DIRECTORY}/data/settings/${name}"
+    if ! test -f "$DIRECTORY"/data/settings/"$name" || wc -c <"$DIRECTORY"/data/settings/"$name" | xargs test 0 =;then
+      <"$DIRECTORY"/etc/setting-params/"$name" grep -v '#' | head -n 1 >"$DIRECTORY"/data/settings/"$name"
     fi
   done
-  IFS="$PREIFS"
   exit 0
   
 elif [ "$1" == 'revert' ];then #If $1 equals 'revert', then overwrite all settings with the defaults and then the script will exit.

--- a/settings
+++ b/settings
@@ -182,10 +182,10 @@ echo "Output: ${output}EOO"
 settingnumber=1
 for setting in "$DIRECTORY"/etc/setting-params/*
 do
-  curval="$(printf '%s\n' "$output" | sed -n "${settingnumber}p")"
+  printf '%s\n' "$output" \
+    | sed -n "${settingnumber}p" \
+    | tee "$DIRECTORY/data/settings/$name" \
+    | xargs printf 'Set "%s" to "%s\n"' "$setting"
 
-  printf 'Setting "%s" to "%s"' "$setting" "$curval"
-  printf "$curval\n" >"$DIRECTORY/data/settings/$name"
-  
   settingnumber=$(printf '1 + %s\n' "$settingnumber" | bc)
 done

--- a/settings
+++ b/settings
@@ -179,21 +179,13 @@ output="$(printf '%s\n' "$output" | sed '/^$/d')"
 
 echo "Output: ${output}EOO"
 
-settings="$(ls "${DIRECTORY}/etc/setting-params" | tr '\n' '|')"
-
 settingnumber=1
-
-PREIFS="$IFS"
-IFS='|'
-for name in $settings
+for setting in "$DIRECTORY"/etc/setting-params/*
 do
   curval="$(printf '%s\n' "$output" | sed -n "${settingnumber}p")"
 
-  printf 'Setting "%s" to "%s"' "$name" "$curval"
+  printf 'Setting "%s" to "%s"' "$setting" "$curval"
   printf "$curval\n" >"$DIRECTORY/data/settings/$name"
   
   settingnumber=$(printf '1 + %s\n' "$settingnumber" | bc)
 done
-IFS="$PREIFS"
-
-

--- a/settings
+++ b/settings
@@ -16,9 +16,9 @@ if [ ! -d "${DIRECTORY}/data/settings" ];then
   echo '' > "${DIRECTORY}/data/settings/reinstall-after-update"
 fi
 
-#$1 is usually left blank. If it equals 'refresh', then empty settings will be created and then the script will exit.
-if [ "$1" == 'refresh' ];then
-  #set default settings, if they don't exist
+# $1 is usually left blank, but there are some dedicated utility subcommands
+case "$1" in
+refresh) # Set default settings, if they don't exist.
   for setting in "$DIRECTORY"/etc/setting-params/*
   do
     if ! test -f "$DIRECTORY"/data/settings/"$(basename "$setting")" \
@@ -28,16 +28,15 @@ if [ "$1" == 'refresh' ];then
     fi
   done
   exit 0
-  
-elif [ "$1" == 'revert' ];then #If $1 equals 'revert', then overwrite all settings with the defaults and then the script will exit.
-  
-  #overwrite all settings with the defaults
+  ;;
+revert) # Overwrite all settings with the defaults.
   for setting in "$DIRECTORY"/etc/setting/params/*
   do
     <"$setting" grep -v '#' | head -n 1 >"$DIRECTORY"/data/settings/"$(basename "$setting")"
   done
   exit 0
-fi
+  ;;
+esac
 
 if [ ! -f ~/.local/share/applications/pi-apps-settings.desktop ];then
   echo "Creating Settings menu button"

--- a/settings
+++ b/settings
@@ -188,7 +188,7 @@ do
   printf '%s\n' "$output" \
     | sed -n "${settingnumber}p" \
     | tee "$DIRECTORY/data/settings/$(basename "$setting")" \
-    | xargs printf 'Set "%s" to "%s\n"' "$(basename "$setting")"
+    | xargs printf 'Set "%s" to "%s"\n' "$(basename "$setting")"
 
   settingnumber=$(printf '1 + %s\n' "$settingnumber" | bc)
 done

--- a/settings
+++ b/settings
@@ -187,12 +187,12 @@ PREIFS="$IFS"
 IFS='|'
 for name in $settings
 do
-  curval="$(echo "$output" | sed -n "${settingnumber}p")"
+  curval="$(printf '%s\n' "$output" | sed -n "${settingnumber}p")"
+
+  printf 'Setting "%s" to "%s"' "$name" "$curval"
+  printf "$curval\n" >"$DIRECTORY/data/settings/$name"
   
-  echo "Setting '$name' to '$curval'"
-  echo "$curval" > "${DIRECTORY}/data/settings/${name}"
-  
-  settingnumber=$((settingnumber + 1))
+  settingnumber=$(printf '1 + %s\n' "$settingnumber" | bc)
 done
 IFS="$PREIFS"
 

--- a/settings
+++ b/settings
@@ -18,6 +18,8 @@ fi
 
 # $1 is usually left blank, but there are some dedicated utility subcommands
 case "$1" in
+'') # GUI.
+  ;;
 refresh) # Set default settings, if they don't exist.
   for setting in "$DIRECTORY"/etc/setting-params/*
   do

--- a/settings
+++ b/settings
@@ -175,7 +175,7 @@ $(echo "$params" | grep -vx "$curval")"
 done
 
 #remove empty lines from $output
-output="$(echo "$output" | grep .)"
+output="$(printf '%s\n' "$output" | sed '/^$/d')"
 
 echo "Output: ${output}EOO"
 


### PR DESCRIPTION
I noticed there was some tricky IFS usage to separate file names, but shell can do that in a for loop anyway, so I went ahead and cleaned all that up as well as making some other small changes for readability. Functionality should be equivalent except that `settings help` shows a help screen now.