### PR TITLE
Tidy up add_to_list in manage

### DIFF
--- a/manage
+++ b/manage
@@ -218,26 +218,19 @@ if [ "$1" == 'daemon' ];then
   #this folder will contain the runtime files necessary to make the daemon work.
   mkdir -p "${DIRECTORY}/data/manage-daemon"
   
-  #a list of pending steps is displayed with yad. This function adds an item to the list
-  add_to_list() { # $1 is action, $2 is app, $3 is exit code status ('0' = success), $4 is output location (usually blank, but can be 'stdout')
+  # This function adds an item to the list of pending actions displayed by yad.
+  #   $1 - action
+  #   $2 - app
+  #   $3 - exit status ('0' is success)
+  #   $4 - output location ('stdout' if standard output, otherwise the list)
+  add_to_list() {
     # $action is used for status messages, so trim off the -file if it's there.
     test "$1" = update-file \
       && action=update \
       || action="$1"
-    local app="$2"
-    local status="$3"
     
-    # $4 specifies where the output should go.
-    # If this is anything other than "stdout", output goes to the yadlist pipe.
-    local output="$4"
-    
-    # If the output is anything other than "stdout", it goes to the yadlist pipe.
-    test "$output" = stdout \
-      && output=/dev/stdout \
-      || output="$DIRECTORY"/data/manage-daemon/yadlist
-
     printf '(icon)\n(action)\n(icon)\n(app)\n' \
-      | case "$status" in
+      | case "$3" in
         # This action has not occured yet.
         '')          sed -e "1c $DIRECTORY/icons/wait.png"    -e "2c Will $action" ;;
         # This action completed successfully.
@@ -247,16 +240,16 @@ if [ "$1" == 'daemon' ];then
         # If status is 1, then action completed unsuccessfully.
         *)           sed -e "1c $DIRECTORY/icons/failure.png" -e "2c ${action^} failed" ;;
         esac \
-      | sed -e "4c $app" \
-      | if test -f "$DIRECTORY"/apps/"$app"/icon-24.png ;then
-          sed -e "3c $DIRECTORY/apps/$app/icon-24.png"
+      | sed -e "4c $2" \
+      | if test -f "$DIRECTORY"/apps/"$2"/icon-24.png ;then
+          sed -e "3c $DIRECTORY/apps/$2/icon-24.png"
         elif test "$1" = update-file ;then
           # Display icon relevant to file type.
-          case "$DIRECTORY"/"$app" in
+          case "$DIRECTORY"/"$2" in
           *.png) sed -e "3c $DIRECTORY/icons/image.png" -e '4s/$/ (image)/' ;;
           *.svg) sed -e "3c $DIRECTORY/icons/image.png" -e '4s/$/ (image)/' ;;
           *)
-            if file -b --mime-type "$DIRECTORY/$app" | xargs test text/x-shellscript = ;then
+            if file -b --mime-type "$DIRECTORY/$2" | xargs test text/x-shellscript = ;then
               # pi-apps shell script
               sed -e "3c $DIRECTORY/icons/shellscript.png" -e '4s/$/ (script)/'
             else
@@ -268,7 +261,14 @@ if [ "$1" == 'daemon' ];then
         else
           sed -e "3c $DIRECTORY/icons/none-24.png"
         fi \
-      >"$output"
+      | if test "$4" = output ;then
+        # $4 specifies where the output should go.
+        # If the output is anything other than "stdout", it goes to the yadlist
+        # pipe.
+          cat
+        else
+          cat >"$DIRECTORY"/data/manage-daemon/yadlist
+        fi
   }
   
   clear_list() { #clear the queue-viewer window

--- a/manage
+++ b/manage
@@ -224,7 +224,8 @@ if [ "$1" == 'daemon' ];then
     local app="$2"
     local status="$3"
     
-    # $4 specifies where the output should go. Default is to send the output to the yadlist pipe, but if value is 'stdout', output to stdout.
+    # $4 specifies where the output should go.
+    # If this is anything other than "stdout", output goes to the yadlist pipe.
     local output="$4"
     
     #choose an icon for this app or file being updated/installed
@@ -279,12 +280,12 @@ $icon
 $app"
     fi
     
-    #write the output to yadlist or stdout
-    if [ "$output" == stdout ];then
-      echo "$content"
-    else
-      echo "$content" > "${DIRECTORY}/data/manage-daemon/yadlist"
-    fi
+    # If the output is anything other than "stdout", it goes to the yadlist pipe.
+    test "$output" = stdout \
+      && output=/dev/stdout \
+      || output="$DIRECTORY"/data/manage-daemon/yadlist
+
+    printf '%s\n' "$content" >"$output"
   }
   
   clear_list() { #clear the queue-viewer window

--- a/manage
+++ b/manage
@@ -261,7 +261,7 @@ if [ "$1" == 'daemon' ];then
         else
           sed -e "3c $DIRECTORY/icons/none-24.png"
         fi \
-      | if test "$4" = output ;then
+      | if test "$4" = stdout ;then
         # $4 specifies where the output should go.
         # If the output is anything other than "stdout", it goes to the yadlist
         # pipe.

--- a/manage
+++ b/manage
@@ -220,35 +220,16 @@ if [ "$1" == 'daemon' ];then
   
   #a list of pending steps is displayed with yad. This function adds an item to the list
   add_to_list() { # $1 is action, $2 is app, $3 is exit code status ('0' = success), $4 is output location (usually blank, but can be 'stdout')
-    local action="$1"
+    # $action is used for status messages, so trim off the -file if it's there.
+    test "$1" = update-file \
+      && action=update \
+      || action="$1"
     local app="$2"
     local status="$3"
     
     # $4 specifies where the output should go.
     # If this is anything other than "stdout", output goes to the yadlist pipe.
     local output="$4"
-    
-    #choose an icon for this app or file being updated/installed
-    if [ -f "${DIRECTORY}/apps/$app/icon-24.png" ];then
-      local icon="${DIRECTORY}/apps/$app/icon-24.png"
-    elif [ "$action" == update-file ];then
-      #determine mimetype of file to display an informative icon in the list
-      if [ "$(file -b --mime-type "${DIRECTORY}/${app}")" == 'text/x-shellscript' ];then
-        #if updatable file in question is a main pi-apps shell script, then display shellscript icon.
-        local icon="${DIRECTORY}/icons/shellscript.png"
-        app+=' (script)'
-      elif [[ "${DIRECTORY}/${app}" == *.png ]] || [[ "${DIRECTORY}/${app}" == *.svg ]];then
-        local icon="${DIRECTORY}/icons/image.png"
-        app+=' (image)'
-      else
-        #otherwise display txt icon.
-        local icon="${DIRECTORY}/icons/txt.png"
-        app+=' (file)'
-      fi
-      action=update
-    else
-      local icon="${DIRECTORY}/icons/none-24.png"
-    fi
     
     # If the output is anything other than "stdout", it goes to the yadlist pipe.
     test "$output" = stdout \
@@ -266,8 +247,27 @@ if [ "$1" == 'daemon' ];then
         # If status is 1, then action completed unsuccessfully.
         *)           sed -e "1c $DIRECTORY/icons/failure.png" -e "2c ${action^} failed" ;;
         esac \
-      | sed -e "3c $icon" \
       | sed -e "4c $app" \
+      | if test -f "$DIRECTORY"/apps/"$app"/icon-24.png ;then
+          sed -e "3c $DIRECTORY/apps/$app/icon-24.png"
+        elif test "$1" = update-file ;then
+          # Display icon relevant to file type.
+          case "$DIRECTORY"/"$app" in
+          *.png) sed -e "3c $DIRECTORY/icons/image.png" -e '4s/$/ (image)/' ;;
+          *.svg) sed -e "3c $DIRECTORY/icons/image.png" -e '4s/$/ (image)/' ;;
+          *)
+            if file -b --mime-type "$DIRECTORY/$app" | xargs test text/x-shellscript = ;then
+              # pi-apps shell script
+              sed -e "3c $DIRECTORY/icons/shellscript.png" -e '4s/$/ (script)/'
+            else
+              # unknown file
+              sed -e "3c $DIRECTORY/icons/txt.png" -e '4s/$/ (file)/'
+            fi
+            ;;
+          esac
+        else
+          sed -e "3c $DIRECTORY/icons/none-24.png"
+        fi \
       >"$output"
   }
   

--- a/manage
+++ b/manage
@@ -250,36 +250,20 @@ if [ "$1" == 'daemon' ];then
       local icon="${DIRECTORY}/icons/none-24.png"
     fi
     
-    if [ -z "$status" ];then
-      #if there is no status number, then this action has not occured yet.
-      local content="${DIRECTORY}/icons/wait.png
-${DIRECTORY}/icons/$action.png
-Will $action
-$icon
-$app"
-    elif [ "$status" == 0 ];then
-      #if status is 0, then action completed successfully.
-      local content="${DIRECTORY}/icons/success.png
-${DIRECTORY}/icons/$action.png
-$(echo "${action^}ed" | sed 's/Updateed/Updated/g')
-$icon
-$app"
-    elif [ "$status" == 'in-progress' ];then
-      #if status is "in-progress", then action is currently being executed.
-      local content="${DIRECTORY}/icons/prompt.png
-${DIRECTORY}/icons/$action.png
-$(echo "${action^}ing..." | sed 's/Updateing/Updating/g')
-$icon
-$app"
-    else
-      #if status is 1, then action completed unsuccessfully.
-      local content="${DIRECTORY}/icons/failure.png
-${DIRECTORY}/icons/$action.png
-${action^} failed
-$icon
-$app"
-    fi
-    
+    local content="$(
+      printf '(icon)\n(action)\n%s\n%s\n' "$icon" "$app" \
+        | case "$status" in
+          # This action has not occured yet.
+          '')          sed -e "1c $DIRECTORY/icons/wait.png"    -e "2c Will $action" ;;
+          # This action completed successfully.
+          0)           sed -e "1c $DIRECTORY/icons/success.png" -e "2c ${action^}ed" -e 's/Updateed/Updated/g' ;;
+          # This action is currently being executed.
+          in-progress) sed -e "1c $DIRECTORY/icons/prompt.png"  -e "2c ${action^}ing..." -e 's/Updateing/Updating/g' ;;
+          # If status is 1, then action completed unsuccessfully.
+          *)           sed -e "1c $DIRECTORY/icons/failure.png" -e "2c ${action^} failed" ;;
+          esac
+    )"
+
     # If the output is anything other than "stdout", it goes to the yadlist pipe.
     test "$output" = stdout \
       && output=/dev/stdout \

--- a/manage
+++ b/manage
@@ -255,7 +255,7 @@ if [ "$1" == 'daemon' ];then
       && output=/dev/stdout \
       || output="$DIRECTORY"/data/manage-daemon/yadlist
 
-    printf '(icon)\n(action)\n%s\n%s\n' "$icon" "$app" \
+    printf '(icon)\n(action)\n(icon)\n(app)\n' \
       | case "$status" in
         # This action has not occured yet.
         '')          sed -e "1c $DIRECTORY/icons/wait.png"    -e "2c Will $action" ;;
@@ -266,6 +266,8 @@ if [ "$1" == 'daemon' ];then
         # If status is 1, then action completed unsuccessfully.
         *)           sed -e "1c $DIRECTORY/icons/failure.png" -e "2c ${action^} failed" ;;
         esac \
+      | sed -e "3c $icon" \
+      | sed -e "4c $app" \
       >"$output"
   }
   

--- a/manage
+++ b/manage
@@ -250,26 +250,23 @@ if [ "$1" == 'daemon' ];then
       local icon="${DIRECTORY}/icons/none-24.png"
     fi
     
-    local content="$(
-      printf '(icon)\n(action)\n%s\n%s\n' "$icon" "$app" \
-        | case "$status" in
-          # This action has not occured yet.
-          '')          sed -e "1c $DIRECTORY/icons/wait.png"    -e "2c Will $action" ;;
-          # This action completed successfully.
-          0)           sed -e "1c $DIRECTORY/icons/success.png" -e "2c ${action^}ed" -e 's/Updateed/Updated/g' ;;
-          # This action is currently being executed.
-          in-progress) sed -e "1c $DIRECTORY/icons/prompt.png"  -e "2c ${action^}ing..." -e 's/Updateing/Updating/g' ;;
-          # If status is 1, then action completed unsuccessfully.
-          *)           sed -e "1c $DIRECTORY/icons/failure.png" -e "2c ${action^} failed" ;;
-          esac
-    )"
-
     # If the output is anything other than "stdout", it goes to the yadlist pipe.
     test "$output" = stdout \
       && output=/dev/stdout \
       || output="$DIRECTORY"/data/manage-daemon/yadlist
 
-    printf '%s\n' "$content" >"$output"
+    printf '(icon)\n(action)\n%s\n%s\n' "$icon" "$app" \
+      | case "$status" in
+        # This action has not occured yet.
+        '')          sed -e "1c $DIRECTORY/icons/wait.png"    -e "2c Will $action" ;;
+        # This action completed successfully.
+        0)           sed -e "1c $DIRECTORY/icons/success.png" -e "2c ${action^}ed" -e 's/Updateed/Updated/g' ;;
+        # This action is currently being executed.
+        in-progress) sed -e "1c $DIRECTORY/icons/prompt.png"  -e "2c ${action^}ing..." -e 's/Updateing/Updating/g' ;;
+        # If status is 1, then action completed unsuccessfully.
+        *)           sed -e "1c $DIRECTORY/icons/failure.png" -e "2c ${action^} failed" ;;
+        esac \
+      >"$output"
   }
   
   clear_list() { #clear the queue-viewer window


### PR DESCRIPTION
While looking at the add_to_list function in manage I noticed the function could probably be implemented as a single shell pipeline, so I went ahead and did that. Instead of bouncing local variables around and using Bash features to sculpt everything before spitting it out, this leans on sed(1p) to chip away at a stream as it slowly forms into the desired output.