### PR TITLE
More support for new terminal logo

### DIFF
--- a/api
+++ b/api
@@ -61,10 +61,10 @@ generate_logo() { #display colorized Pi-Apps logo in terminal
     local version="$(readlink -f /usr/lib/aarch64-linux-gnu/libicudata.so | sed -n 's/.*libicudata.so.//p')"
   elif [ -f /usr/lib/arm-linux-gnueabihf/libicudata.so ]; then
     local version="$(readlink -f /usr/lib/arm-linux-gnueabihf/libicudata.so | sed -n 's/.*libicudata.so.//p')"
-  elif find /usr/lib/aarch64-linux-gnu/libicudata.so* | grep .; then
-    local version="$(find /usr/lib/aarch64-linux-gnu/libicudata.so.* | sed -n 's/\/usr\/lib\/aarch64-linux-gnu\/libicudata.so.//p' | head -1)"
-  elif find /usr/lib/arm-linux-gnueabihf/libicudata.so* | grep .; then
-    local version="$(find /usr/lib/arm-linux-gnueabihf/libicudata.so.* | sed -n 's/\/usr\/lib\/arm-linux-gnueabihf\/libicudata.so.//p' | head -1)"
+  elif find /usr/lib/aarch64-linux-gnu/libicudata.so* &>/dev/null; then
+    local version="$(find /usr/lib/aarch64-linux-gnu/libicudata.so.* | head -1 | sed -n 's/\/usr\/lib\/aarch64-linux-gnu\/libicudata.so.//p')"
+  elif find /usr/lib/arm-linux-gnueabihf/libicudata.so* &>/dev/null; then
+    local version="$(find /usr/lib/arm-linux-gnueabihf/libicudata.so.* | head -1 | sed -n 's/\/usr\/lib\/arm-linux-gnueabihf\/libicudata.so.//p')"
   else
     local version="65"
   fi

--- a/api
+++ b/api
@@ -61,8 +61,10 @@ generate_logo() { #display colorized Pi-Apps logo in terminal
     local version="$(readlink -f /usr/lib/aarch64-linux-gnu/libicudata.so | sed -n 's/.*libicudata.so.//p')"
   elif [ -f /usr/lib/arm-linux-gnueabihf/libicudata.so ]; then
     local version="$(readlink -f /usr/lib/arm-linux-gnueabihf/libicudata.so | sed -n 's/.*libicudata.so.//p')"
-  elif [ -f /usr/lib/arm-linux-gnueabihf/libicudata.so.67.1 ] || [ -f /usr/lib/aarch64-linux-gnu/libicudata.so.67.1 ];then
-    local version=67.1
+  elif find /usr/lib/aarch64-linux-gnu/libicudata.so* | grep .; then
+    local version="$(find /usr/lib/aarch64-linux-gnu/libicudata.so.* | sed -n 's/\/usr\/lib\/aarch64-linux-gnu\/libicudata.so.//p' | head -1)"
+  elif find /usr/lib/arm-linux-gnueabihf/libicudata.so* | grep .; then
+    local version="$(find /usr/lib/arm-linux-gnueabihf/libicudata.so.* | sed -n 's/\/usr\/lib\/arm-linux-gnueabihf\/libicudata.so.//p' | head -1)"
   else
     local version="65"
   fi


### PR DESCRIPTION
This small PR will probably permit to all supported users to get the new logo. it just read the version from the names of the libicudata.so.${version} files. 