### PR TITLE
Correct typo in "SLD2" to "SDL2"

### DIFF
--- a/apps/Pac-Man/description
+++ b/apps/Pac-Man/description
@@ -1,3 +1,3 @@
-Pac-Man clone in SLD2 and C/C++
+Pac-Man clone in SDL2 and C/C++
 To run: Menu -> Games -> Pacman (SDL)
 To run in a terminal: pacman_sdl


### PR DESCRIPTION
Fixes typo in description of the app Pac-Man from "SLD2" to "SDL2"