### PR TITLE
Fix typo and remove confusing description line

### DIFF
--- a/apps/Renoise (Demo)/credits
+++ b/apps/Renoise (Demo)/credits
@@ -1,3 +1,3 @@
 Thanks to:
  - Renoise developer for making Renoise, and providing Raspberry Pi builds!
- - @Crilum on GitHub for adding teh app to Pi-Apps
+ - @Crilum on GitHub for adding the app to Pi-Apps

--- a/apps/Renoise (Demo)/description
+++ b/apps/Renoise (Demo)/description
@@ -5,7 +5,6 @@ Already known to be a very feature-complete software, version 3 improves on core
 This version is only a demo, you can buy the full version at: https://www.renoise.com/shop
 Renoise Demo Restrictions
 
- · No ASIO support on Windows
  · Rendering to .wav is disabled
  · Rendering/resampling selections is disabled
  · Rendering/freezing plugin instruments to samples is disabled


### PR DESCRIPTION
### Changes

- I found a typo in the `credits` file for Renoise (Demo).
- I think the line in the current description that mentions ASIO support for Windows isn't really relevant to the Demo Limitations for Linux, so I removed it.  :+1: 