### PR TITLE
Fix obtaining version and binaries for LibreWolf

### DIFF
--- a/.github/workflows/updates/LibreWolf.sh
+++ b/.github/workflows/updates/LibreWolf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-webVer=$(curl -s "https://gitlab.com/api/v4/projects/44042130/releases" | tr '{},[]' '\n' | grep -x '"direct_asset_url":.*linux-arm64-package.tar.bz2"' -m1 | sed 's+.*/packages/generic/librewolf/++g ; s+/.*++g')
-arm64_url="https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/${webVer}/librewolf-${webVer}-linux-arm64-package.tar.bz2"
+webVer=$(curl -s "https://gitlab.com/api/v4/projects/44042130/releases" | tr '{},[]' '\n' | grep -x '"direct_asset_url":.*linux-arm64-package.tar.xz"' -m1 | sed 's+.*/packages/generic/librewolf/++g ; s+/.*++g')
+arm64_url="https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/${webVer}/librewolf-${webVer}-linux-arm64-package.tar.xz"
 
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh


### PR DESCRIPTION
As LibreWolf is now publishing `.xz` packages instead of `.bz2` ones, this pull request fixes obtaining the version and URL of the arm64 package.

The LibreWolf version in Pi-Apps is still version `134.0.2-1`, which is over 6 months old.