### PR TITLE
Update `install-64` for LibreWolf to work with new `xz` archives

### DIFF
--- a/apps/LibreWolf/install-64
+++ b/apps/LibreWolf/install-64
@@ -12,10 +12,10 @@ fi
 install_packages "${depends[@]}" lsb-release libatk1.0-0 libc6 libcairo-gobject2 libcairo2 libdbus-1-3 libdbus-glib-1-2 libfontconfig1 libfreetype6 libgcc-s1 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libharfbuzz0b libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb-shm0 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxtst6 || exit 1
 
 sudo rm -rf /tmp/librewolf /opt/librewolf
-wget -O /tmp/librewolf.tar.bz2 "https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/${version}/librewolf-${version}-linux-arm64-package.tar.bz2" || exit 1
+wget -O /tmp/librewolf.tar.xz "https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/${version}/librewolf-${version}-linux-arm64-package.tar.xz" || exit 1
 mkdir -p /tmp/librewolf
-status "Extracting: /tmp/librewolf.tar.bz2"
-tar --strip-components=1 -xf /tmp/librewolf.tar.bz2 -C /tmp/librewolf || error "Failed to extract librewolf tarfile!"
+status "Extracting: /tmp/librewolf.tar.xz"
+tar --strip-components=1 -xf /tmp/librewolf.tar.xz -C /tmp/librewolf || error "Failed to extract librewolf tarfile!"
 
 sudo mv -f /tmp/librewolf /opt || error "Failed to move extracted librewolf folder to /opt!"
 


### PR DESCRIPTION
I'm so sorry about another PR, I thought this commit had pushed and was submitted with the other one (#2812)!

This PR updates LibreWolf's `install-64` to use the `xz` archive links instead of the older `bz2` archives.