### PR TITLE
Simplify uninstall script by removing set -e

### DIFF
--- a/apps/En Croissant/uninstall
+++ b/apps/En Croissant/uninstall
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 sudo rm -f /usr/local/bin/en-croissant
 sudo rm -f /usr/local/share/icons/en-croissant.png
 


### PR DESCRIPTION
Remove unnecessary set command from uninstall script. I don't think it really makes any difference but I forgot to remove it when I removed it from the install script.