### PR TITLE
Download link for most current version of FeeCAD was updated.

### DIFF
--- a/.github/workflows/updates/FreeCAD.sh
+++ b/.github/workflows/updates/FreeCAD.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 version=$(get_release FreeCAD/FreeCAD)
-arm64_url="https://github.com/FreeCAD/FreeCAD/releases/download/${version}/FreeCAD_${version}-conda-Linux-aarch64-py311.AppImage"
+arm64_url="https://github.com/FreeCAD/FreeCAD/releases/download/${version}/FreeCAD_${version}-Linux-aarch64-py311.AppImage"
 
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh

--- a/apps/FreeCAD/install-64
+++ b/apps/FreeCAD/install-64
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-version=1.0.2
+version=1.1.1
 
-wget -O /tmp/FreeCAD.AppImage "https://github.com/FreeCAD/FreeCAD/releases/download/${version}/FreeCAD_${version}-conda-Linux-aarch64-py311.AppImage" || exit 1
+wget -O /tmp/FreeCAD.AppImage "https://github.com/FreeCAD/FreeCAD/releases/download/${version}/FreeCAD_${version}-Linux-aarch64-py311.AppImage" || exit 1
 
 sudo mv -f /tmp/FreeCAD.AppImage /opt/FreeCAD.AppImage || error "Failed to move AppImage to /opt"
 


### PR DESCRIPTION
Changes in the FreeCAD installer shell script:
- FreeCAD-version was set to v1.1.1
- The download link pointing to the most current version of the AppImage of FeeCAD was updated

This is my first commit ever on GitHub, so please be kind, should I have made any mistakes ... thanks!