### PR TITLE
Allow passing in value for DIRECTORY

### DIFF
--- a/install
+++ b/install
@@ -50,10 +50,12 @@ fi
 #remove annoying "YAD icon browser" launcher
 sudo rm -f /usr/share/applications/yad-icon-browser.desktop
 
-#download pi-apps if folder missing
-DIRECTORY="$(readlink -f "$(dirname "$0")")"
-if [ -z "$DIRECTORY" ] || [ "$DIRECTORY" == "$HOME" ] || [ "$DIRECTORY" == bash ] || [ ! -f "${DIRECTORY}/api" ] || [ ! -f "${DIRECTORY}/gui" ];then
-  DIRECTORY="$HOME/pi-apps"
+if [ -z "$DIRECTORY" ]; then
+  #download pi-apps if folder missing
+  DIRECTORY="$(readlink -f "$(dirname "$0")")"
+  if [ -z "$DIRECTORY" ] || [ "$DIRECTORY" == "$HOME" ] || [ "$DIRECTORY" == bash ] || [ ! -f "${DIRECTORY}/api" ] || [ ! -f "${DIRECTORY}/gui" ];then
+    DIRECTORY="$HOME/pi-apps"
+  fi
 fi
 downloaded=0 #track if pi-apps was downloaded this time
 


### PR DESCRIPTION
Tiny change that allows something like:

env DIRECTORY="${HOME}/.pi-apps" ./install

I was excited to discover that DIRECTORY is used consistently throughout the repo, thanks for that, regardless of whether you accept this change or not :)