### PR TITLE
Browsh, Winlink Express, XSnow: bump to latest versions

### DIFF
--- a/apps/Browsh/install-32
+++ b/apps/Browsh/install-32
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=1.8.2
+version=1.8.3
 
 install_packages firefox-esr '|' firefox https://github.com/browsh-org/browsh/releases/download/v${version}/browsh_${version}_linux_armv7.deb || exit 1
 

--- a/apps/Browsh/install-64
+++ b/apps/Browsh/install-64
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=1.8.2
+version=1.8.3
 
 install_packages firefox-esr '|' firefox https://github.com/browsh-org/browsh/releases/download/v${version}/browsh_${version}_linux_arm64.deb || exit 1
 

--- a/apps/Winlink Express/install
+++ b/apps/Winlink Express/install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=User%20Programs/Winlink_Express_install_1-8-2-0.zip
+version=User%20Programs/Winlink_Express_install_1-8-4-0.zip
 
 APPDIR="${HOME}"/.local/share/applications/Winlink
 

--- a/apps/XSnow/install
+++ b/apps/XSnow/install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=3.9.2
+version=3.9.3
 
 install_packages build-essential libx11-dev libxpm-dev libxt-dev libxext-dev pkg-config libxml2-dev libgtk-3-dev libxinerama-dev libxtst-dev libgsl-dev libopencv-dev || exit 1
 


### PR DESCRIPTION
The old download URLs for these apps returned 404. Updated to the latest upstream versions.