### PR TITLE
Rework Ruffle installer to use prebuilt binary on ARM64

### DIFF
--- a/.github/workflows/updates/Ruffle.sh
+++ b/.github/workflows/updates/Ruffle.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 version=$(get_prerelease ruffle-rs/ruffle)
-all_url="https://github.com/ruffle-rs/ruffle/tree/$version"
+filename_version="${version//-/_}"
+all_url="https://github.com/ruffle-rs/ruffle/releases/download/${version}/ruffle-nightly-${filename_version}-linux-aarch64.tar.gz"
 
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh

--- a/apps/Ruffle/install
+++ b/apps/Ruffle/install
@@ -1,66 +1,75 @@
 #!/bin/bash
 
-version=nightly-2026-06-05
+version=nightly-2026-07-30
 
-# Purge any existing Ruffle instances if already found
-status "Purging any existing Ruffle copies and code if found"
+# Purge any existing Ruffle instances
 sudo rm -rf /tmp/ruffle-$version ~/ruffle
 
 if ! [ "$1" == update ];then
   sudo rm -rf /opt/ruffle
 fi
 
-status "Checking Rust compiler for compatibility"
+if [ "$arch" == 64 ]; then
+  # Use prebuilt binary on 64-bit ARM (much faster than compiling from source)
+  filename_version="${version//-/_}"
+  wget "https://github.com/ruffle-rs/ruffle/releases/download/${version}/ruffle-nightly-${filename_version}-linux-aarch64.tar.gz" -O /tmp/ruffle.tar.gz || error "Failed to download Ruffle!"
 
-# simplified version checking
-if package_is_new_enough rustc 1.89.0; then echo "Rust compiler available in the package repositories is new enough, installing from package repositories" && rust_too_old=0; else echo "Rust compiler is too old in available package repositories, installing latest version via rustup" && rust_too_old=1; fi
+  if [ "$1" == update ]; then
+    sudo tar xf /tmp/ruffle.tar.gz -C /opt/ruffle --strip-components=1 || error "Failed to extract Ruffle!"
+    rm -f /tmp/ruffle.tar.gz
+    status_green "Ruffle updated successfully"
+    exit 0
+  fi
 
-if [ "$rust_too_old" -eq "1" ]; then
-    echo "Installing newer Rust toolchain"
-    wget -O /tmp/rustup-init.sh https://sh.rustup.rs
-    sudo chmod +x /tmp/rustup-init.sh
-    /tmp/rustup-init.sh -y
-    . "$HOME/.cargo/env"
-    status "Installing dependencies without a Rust toolchain"
-    install_packages libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev libudev-dev libxcb-xinput-dev libxcb-xkb-dev libxcb-cursor-dev default-jre-headless cmake g++ || exit 1
+  sudo mkdir -p /opt/ruffle || error "Failed to make Ruffle folder in /opt!"
+  sudo tar xf /tmp/ruffle.tar.gz -C /opt/ruffle --strip-components=1 || error "Failed to extract Ruffle!"
+  rm -f /tmp/ruffle.tar.gz
 else
-    echo "Rust too old variable is at 0, installing Rust toolchain and dependencies via distro's repositories"
-    install_packages cargo rustc libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev libudev-dev libxcb-xinput-dev libxcb-xkb-dev libxcb-cursor-dev default-jre-headless cmake g++ || exit 1
+  # 32-bit ARM: no prebuilt binary available, compile from source
+  status "Checking Rust compiler for compatibility"
+
+  if package_is_new_enough rustc 1.89.0; then echo "Rust compiler available in the package repositories is new enough, installing from package repositories" && rust_too_old=0; else echo "Rust compiler is too old in available package repositories, installing latest version via rustup" && rust_too_old=1; fi
+
+  if [ "$rust_too_old" -eq "1" ]; then
+      echo "Installing newer Rust toolchain"
+      wget -O /tmp/rustup-init.sh https://sh.rustup.rs
+      sudo chmod +x /tmp/rustup-init.sh
+      /tmp/rustup-init.sh -y
+      . "$HOME/.cargo/env"
+      install_packages libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev libudev-dev libxcb-xinput-dev libxcb-xkb-dev libxcb-cursor-dev default-jre-headless cmake g++ || exit 1
+  else
+      install_packages cargo rustc libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev libudev-dev libxcb-xinput-dev libxcb-xkb-dev libxcb-cursor-dev default-jre-headless cmake g++ || exit 1
+  fi
+
+  status "Downloading Ruffle source code"
+  git_clone -b "$version" https://github.com/ruffle-rs/ruffle || error 'Failed to clone Ruffle repository!'
+
+  status "Compiling Ruffle, this will take a bit"
+  cd ~/ruffle
+  cargo build --release --package=ruffle_desktop -j$(nproc) || error "Failed to compile Ruffle!"
+  status_green "Compile success"
+
+  cd target/release 
+  mv ruffle_desktop ruffle || error "Failed to rename Ruffle binary!"
+
+  if [ "$1" == update ];then
+    sudo cp ruffle /opt/ruffle/ruffle || error "Failed to copy Ruffle binary!"
+    rm -rf ~/ruffle
+    status_green "Ruffle updated successfully"
+    exit 0
+  fi
+
+  sudo mkdir /opt/ruffle || error "Failed to make Ruffle folder in /opt!"
+  sudo cp ruffle /opt/ruffle || error "Failed to copy Ruffle binary to /opt/ruffle!"
+  rm -rf ~/ruffle
 fi
 
-# Download Ruffle source code latest snapshot and compile it
+sudo cp "$(dirname "$0")/icon-64.png" /opt/ruffle || error "Failed to copy Ruffle icon to /opt/ruffle!"
 
-status "Downloading Ruffle source code"
-git_clone -b "$version" https://github.com/ruffle-rs/ruffle || error 'Failed to clone Ruffle repository!'
-
-status "Compiling Ruffle, this will take a bit"
-cd ~/ruffle
-cargo build --release --package=ruffle_desktop -j$(nproc) || error "Failed to compile Ruffle!"
-status_green "Compile success"
-
-# Copy compiled build
-status "Copying release to /opt/ruffle"
-cd target/release 
-mv ruffle_desktop ruffle || error "Failed to rename Ruffle binary!"
-# Only install back Ruffle binary if it's in update mode 
-if [ "$1" == update ];then
-  sudo cp ruffle /opt/ruffle/ruffle || error "Failed to copy Ruffle binary to /opt/ruffle/ruffle!"
-  status "Purging downloaded Ruffle source code version snapshot"
-  sudo rm -rf ~/ruffle
-  exit 0
-fi
-sudo mkdir /opt/ruffle || error "Failed to make Ruffle folder in /opt!" 
-sudo cp ruffle /opt/ruffle || error "Failed to copy Ruffle binary to /opt/ruffle!" 
-sudo cp "$(dirname "$0")/icon-64.png" /opt/ruffle || error "Failed to copy Ruffle icon to /opt/ruffle!" 
-
-# Make command asociations
-status "Making terminal command..."
 echo '#!/bin/bash
 /opt/ruffle/ruffle "$@"' | sudo tee /usr/local/bin/ruffle >/dev/null
 sudo chmod +x /usr/local/bin/ruffle
 
-# Make menu launcher
-status "Making menu launcher..."
 echo "[Desktop Entry]
 Name=Ruffle
 Comment=Open source Flash Player emulator written in Rust
@@ -71,9 +80,6 @@ Type=Application
 Categories=Game;Utility;
 MimeType=application/x-shockwave-flash;" | sudo tee /usr/local/share/applications/ruffle.desktop >/dev/null
 
-# Make .swf files associate to Ruffle
-# Register MIME type
-status "Creating MIME type definition for Ruffle..."
 echo '<?xml version="1.0" encoding="UTF-8"?>
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
     <mime-type type="application/x-shockwave-flash">
@@ -82,13 +88,6 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
     </mime-type>
 </mime-info>' | sudo tee "/usr/share/mime/packages/ruffle.xml" > /dev/null
 
-# Update MIME databases
-status "Updating MIME databases..."
 sudo update-mime-database /usr/share/mime || warning "Failed to update MIME databases."
-
-# Associate SWF files with Ruffle
-status "Associating .swf files with Ruffle..."
 sudo xdg-mime default ruffle.desktop application/x-shockwave-flash || warning "Unable to associate Ruffle with .swf files."
-status "Purging downloaded Ruffle source code version snapshot"
-rm -rf ~/ruffle
 status_green Done


### PR DESCRIPTION
Ruffle now publishes prebuilt ARM64 Linux binaries in their nightly releases. This cuts install time from ~30 minutes (compiling Rust from source) to a few seconds.

64-bit ARM: downloads the prebuilt tarball
32-bit ARM: still compiles from source (no prebuilt available)

Also bumped the nightly version to 2026-07-30.