### PR TITLE
VSCodium: stop trying to update 32-bit ARM builds

### DIFF
--- a/.github/workflows/updates/VSCodium.sh
+++ b/.github/workflows/updates/VSCodium.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 webVer="$(get_release vscodium/vscodium)"
-armhf_url="https://github.com/VSCodium/vscodium/releases/download/${webVer}/codium_${webVer}_armhf.deb"
+# armhf builds no longer published by upstream after v1.121.x
 arm64_url="https://github.com/VSCodium/vscodium/releases/download/${webVer}/codium_${webVer}_arm64.deb"
 
 source $GITHUB_WORKSPACE/.github/workflows/update_github_script.sh


### PR DESCRIPTION
VSCodium no longer publishes armhf .deb packages (they dropped 32-bit ARM support after v1.121.x). The CI auto-updater was trying to update the 32-bit install URL every run and failing. This removes armhf from the updater. The existing install-32 script still uses v1.121.03429 which works fine.