### PR TITLE
Update Tor Browser nightly version

### DIFF
--- a/apps/Tor/install-64
+++ b/apps/Tor/install-64
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=2026.07.19
+version=2026.07.30
 INSTALL_DIR="$HOME/.local/share"
 
 rm -f /tmp/tbb-nightly.tar.xz


### PR DESCRIPTION
The Tor Browser nightly version was pinned to 2026.07.19 which now returns 404.\n\nUpdated to 2026.07.30 (latest available, verified 200 OK).\n\nThe installer uses a nightly build for arm64 while the 32-bit version uses the stable SourceForge release (13.0.9) which is unaffected.