### PR TITLE
Use HTTPS for direct package downloads in KiCad, WPS Office, OBS Studio

### DIFF
--- a/apps/KiCad/install
+++ b/apps/KiCad/install
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if [ "$(get_codename)" == bookworm ];then
-  install_packages http://http.us.debian.org/debian/pool/main/d/debian-archive-keyring/debian-archive-keyring_2025.1_all.deb || exit 1
+  install_packages https://deb.debian.org/debian/pool/main/d/debian-archive-keyring/debian-archive-keyring_2025.1_all.deb || exit 1
   if [ $arch == 32 ]; then
-    install_packages http://http.us.debian.org/debian/pool/main/g/glew/libglew2.2_2.2.0-4+b1_armhf.deb || exit 1
+    install_packages https://deb.debian.org/debian/pool/main/g/glew/libglew2.2_2.2.0-4+b1_armhf.deb || exit 1
   fi
   echo "deb http://deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware" | sudo tee /etc/apt/sources.list.d/bookworm-backports.list >/dev/null
   install_packages -t bookworm-backports kicad kicad-libraries || exit 1

--- a/apps/OBS Studio/install-32
+++ b/apps/OBS Studio/install-32
@@ -43,7 +43,7 @@ if [ "$__os_codename" == "bullseye" ]; then
     fi
     # add debian keyring
     rm -f /tmp/debian-archive-keyring.deb
-    wget -qO /tmp/debian-archive-keyring.deb http://ftp.us.debian.org/debian/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb
+    wget -qO /tmp/debian-archive-keyring.deb https://deb.debian.org/debian/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb || error "Failed to download debian-archive-keyring!"
     apt_lock_wait
     sudo apt install -y /tmp/debian-archive-keyring.deb || error "Failed to install debian-archive-keyring"
     rm -f /tmp/debian-archive-keyring.deb

--- a/apps/WPS Office/install-64
+++ b/apps/WPS Office/install-64
@@ -3,14 +3,14 @@
 if package_is_new_enough firejail 0.9.58 ;then
   firejail_package="firejail"
 else
-  firejail_package="http://ports.ubuntu.com/pool/universe/f/firejail/firejail_0.9.62-3ubuntu0.1_arm64.deb"
+  firejail_package="https://ports.ubuntu.com/pool/universe/f/firejail/firejail_0.9.62-3ubuntu0.1_arm64.deb"
 fi
 
 #install libwebp6 and libtiff5 to get PDF export working
 if package_available libwebp6 && package_available libtiff5 ;then
   install_packages "$firejail_package" "https://github.com/Pi-Apps-Coders/files/releases/download/large-files/wps-office_11.1.0.11720_arm64.deb" libwebp6 libtiff5 ttf-mscorefonts-installer x11-utils wmctrl || exit 1
 else
-  install_packages "$firejail_package" "https://github.com/Pi-Apps-Coders/files/releases/download/large-files/wps-office_11.1.0.11720_arm64.deb" ttf-mscorefonts-installer x11-utils wmctrl "http://ftp.us.debian.org/debian/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_arm64.deb" "http://ftp.debian.org/debian/pool/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_arm64.deb" "http://ftp.debian.org/debian/pool/main/t/tiff/libtiff5_4.2.0-1+deb11u5_arm64.deb" || exit 1
+  install_packages "$firejail_package" "https://github.com/Pi-Apps-Coders/files/releases/download/large-files/wps-office_11.1.0.11720_arm64.deb" ttf-mscorefonts-installer x11-utils wmctrl "https://ftp.debian.org/debian/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_arm64.deb" "https://ftp.debian.org/debian/pool/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_arm64.deb" "https://ftp.debian.org/debian/pool/main/t/tiff/libtiff5_4.2.0-1+deb11u5_arm64.deb" || exit 1
 fi
 
 #make icon symlinks that correspond to WM_CLASS so correct icon is set on Wayland (for main wps window only)


### PR DESCRIPTION
Eight package download URLs were using plain HTTP instead of HTTPS. These are direct .deb downloads (not apt repositories — the package content is not cryptographically verified before installation).\n\nChanges:\n- **KiCad**: debian-archive-keyring and libglew2 downloads → https://deb.debian.org/\n- **WPS Office**: firejail → https://ports.ubuntu.com/; libjpeg62-turbo, libwebp6, libtiff5 → https://ftp.debian.org/\n- **OBS Studio**: debian-archive-keyring download → https://deb.debian.org/ (added missing  on )