### PR TITLE
Add error handling to Pi Power Tools wget-and-pipe-to-bash

### DIFF
--- a/apps/Pi Power Tools/install
+++ b/apps/Pi Power Tools/install
@@ -1,5 +1,9 @@
 #!/bin/bash
 # Get dependencies
 install_packages yad systemd-container xserver-xephyr expect || exit 1
-script=$(wget -O - https://raw.githubusercontent.com/Botspot/Pi-Power-Tools/master/update) || error "Failed to download Pi Power Tools update script!"
-bash <<< "$script" || error "Pi Power Tools updater script failed!"
+wget -O - https://raw.githubusercontent.com/Botspot/Pi-Power-Tools/master/update | bash
+if [ "${PIPESTATUS[0]}" != 0 ];then
+  error "PPT script download failed"
+elif [ "${PIPESTATUS[1]}" != 0 ];then
+  error "PPT script execution failed"
+fi

--- a/apps/Pi Power Tools/install
+++ b/apps/Pi Power Tools/install
@@ -1,4 +1,5 @@
 #!/bin/bash
 # Get dependencies
 install_packages yad systemd-container xserver-xephyr expect || exit 1
-wget -O - https://raw.githubusercontent.com/Botspot/Pi-Power-Tools/master/update | bash
+script=$(wget -O - https://raw.githubusercontent.com/Botspot/Pi-Power-Tools/master/update) || error "Failed to download Pi Power Tools update script!"
+bash <<< "$script" || error "Pi Power Tools updater script failed!"


### PR DESCRIPTION
The install script downloaded and piped an external script to bash with no error checking. If the download failed, the pipe would silently pass empty data to bash, making the script appear to succeed while doing nothing.\n\nChanged to capture the download in a variable first with proper error handling, then pass to bash.